### PR TITLE
Dispatch a custom event when building the podcast data

### DIFF
--- a/.github/workflows/podcast.yml
+++ b/.github/workflows/podcast.yml
@@ -39,3 +39,9 @@ jobs:
       uses: ad-m/github-push-action@master
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Repository Dispatch
+      uses: peter-evans/repository-dispatch@v1
+      with:
+        token: ${{ secrets.REPO_ACCESS_TOKEN }}
+        event-type: rss-data-updated

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches:
       - master
+  repository_dispatch:
+    types: rss-data-updated
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
To get over the gap between the podcast and publish workflow, workflows
can't trigger another workflow, so even though we push to master, it
won't rebuild the site.