### PR TITLE
Update Podcast Script

### DIFF
--- a/_data/elixir_wizards_episodes.yml
+++ b/_data/elixir_wizards_episodes.yml
@@ -22,7 +22,7 @@
     duration: '1:40'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg?v=3
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Welcome back to Season 3! Our theme this time around is
       Working with Elixir. Listen for more on our theme, upcoming guests, and our
       new name.</p>\n      "
@@ -54,7 +54,7 @@
     duration: '1:26'
     explicit: 'no'
     keywords: ''
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg?v=3
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>We’re excited to announce our season two topic, Elixir
       Internals. In this season we talk with developers behind some of the most popular
       Elixir libraries, including Witchcraft, ElixirScript, Distillery, Ecto, and
@@ -91,7 +91,7 @@
     duration: '1:24'
     explicit: 'no'
     keywords: elixir, phoenix, production
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg?v=3
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Welcome to the first season of Smart Software with SmartLogic.
       We&#39;ll be interviewing several companies about how they use Elixir in Production
       this season. In this preview episode, we introduce ourselves and some of the
@@ -104,13 +104,327 @@
     some of the topics we’ll be covering.</p>\n\n<p>Learn more about how SmartLogic
     uses <a href=\"https://smr.tl/2Hyslu8\" rel=\"nofollow\">Phoenix and Elixir.</a></p>\n
     \     "
+- title: 'Tyler Young on Geo Mapping at Felt '
+  slug: s9e3-tyleryoung-felt
+  link: https://smartlogic.io/podcast/elixir-wizards/s9e3-tyleryoung-felt
+  guid: 457bc018-a109-4457-b7bd-693ebd2ef38e
+  pubDate: Thu, 13 Oct 2022 06:00:00 -0400
+  pubDateFriendly: October 13, 2022
+  description: "Today on Elixir Wizards we are joined by Tyler Young to explore the
+    particulars of Geo Mapping, the process of turning data into maps. Tyler is a
+    Senior Software Developer at Felt, the world’s first collaborative mapping tool
+    built for anyone to make a beautiful map in minutes. Tune in today to learn more
+    about Geo Mapping from today’s special guest, Tyler Young!\nKey Points From This
+    Episode:\nA brief breakdown of today’s topic and introduction to our special guest,
+    Tyler Young\nWe discover Tyler’s background and how he started working in Elixir,
+    as well as how he got into the map business because of his love for Elixir \nWe
+    learn about GIS and its history as a system/standard/protocol, and how someone
+    can study GIS \nFind out how mapping is helpful in more ways than just for directions,
+    including climate changes, vacation planning, and more\nTyler breaks down the
+    common technologies and toolkits for programming with maps \nThe specific tools
+    that Felt is using to ingest map data and build the interactive maps \nWhat common
+    problems arise when developing with maps\nTyler teaches the Elixir Wizards about
+    his tried and true way of decision making with “The McDonald’s option” \n_\n**Links
+    Mentioned in Today’s Episode:\nTyler Young on Twitter — https://twitter.com/TylerAYoung\nTyler
+    Young on GitHub — https://github.com/s3cur3\nTyler Young on LinkedIn — https://www.linkedin.com/in/tyler-young-dev/\nFelt
+    — https://felt.com/about\nSmartLogic — https://smartlogic.io/\nSmartLogic Twitter
+    — https://twitter.com/smartlogic\n"
+  author: SmartLogic LLC
+  embedUrl: https://fireside.fm/player/v2/IAs5ixts+373p2LD-
+  enclosure:
+    url: https://aphid.fireside.fm/d/1437767933/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/457bc018-a109-4457-b7bd-693ebd2ef38e.mp3
+    length: '31075529'
+    type: audio/mpeg
+  itunes:
+    episodeType: full
+    season: '9'
+    author: SmartLogic LLC
+    subtitle: Today on Elixir Wizards we are joined by Tyler Young to explore the
+      particulars of Geo Mapping, the process of turning data into maps. Tyler is
+      a Senior Software Developer at Felt, the world’s first collaborative mapping
+      tool built for anyone to make a beautiful map in minutes. Tune in today to learn
+      more about Geo Mapping from today’s special guest, Tyler Young!
+    duration: '36:59'
+    explicit: 'no'
+    keywords: elixir, geo mapping, tech, felt
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
+    summary: "\n        <p>Today on Elixir Wizards we are joined by Tyler Young to
+      explore the particulars of Geo Mapping, the process of turning data into maps.
+      Tyler is a Senior Software Developer at Felt, the world’s first collaborative
+      mapping tool built for anyone to make a beautiful map in minutes. Tune in today
+      to learn more about Geo Mapping from today’s special guest, Tyler Young!</p>\n\n<p>Key
+      Points From This Episode:</p>\n\n<ul>\n<li>A brief breakdown of today’s topic
+      and introduction to our special guest, Tyler Young</li>\n<li>We discover Tyler’s
+      background and how he started working in Elixir, as well as how he got into
+      the map business because of his love for Elixir </li>\n<li>We learn about GIS
+      and its history as a system/standard/protocol, and how someone can study GIS
+      </li>\n<li>Find out how mapping is helpful in more ways than just for directions,
+      including climate changes, vacation planning, and more</li>\n<li>Tyler breaks
+      down the common technologies and toolkits for programming with maps </li>\n<li>The
+      specific tools that Felt is using to ingest map data and build the interactive
+      maps </li>\n<li>What common problems arise when developing with maps</li>\n<li><p>Tyler
+      teaches the Elixir Wizards about his tried and true way of decision making with
+      “The McDonald’s option” <br>\n_<br>\n**Links Mentioned in Today’s Episode:</p></li>\n<li><p>Tyler
+      Young on Twitter — <a href=\"https://twitter.com/TylerAYoung\" rel=\"nofollow\">https://twitter.com/TylerAYoung</a></p></li>\n<li><p>Tyler
+      Young on GitHub — <a href=\"https://github.com/s3cur3\" rel=\"nofollow\">https://github.com/s3cur3</a></p></li>\n<li><p>Tyler
+      Young on LinkedIn — <a href=\"https://www.linkedin.com/in/tyler-young-dev/\"
+      rel=\"nofollow\">https://www.linkedin.com/in/tyler-young-dev/</a></p></li>\n<li><p>Felt
+      — <a href=\"https://felt.com/about\" rel=\"nofollow\">https://felt.com/about</a></p></li>\n<li><p>SmartLogic
+      — <a href=\"https://smartlogic.io/\" rel=\"nofollow\">https://smartlogic.io/</a></p></li>\n<li><p>SmartLogic
+      Twitter — <a href=\"https://twitter.com/smartlogic\" rel=\"nofollow\">https://twitter.com/smartlogic</a></p></li>\n</ul>\n
+      \     "
+  contentEncoded: "\n        <p>Today on Elixir Wizards we are joined by Tyler Young
+    to explore the particulars of Geo Mapping, the process of turning data into maps.
+    Tyler is a Senior Software Developer at Felt, the world’s first collaborative
+    mapping tool built for anyone to make a beautiful map in minutes. Tune in today
+    to learn more about Geo Mapping from today’s special guest, Tyler Young!</p>\n\n<p>Key
+    Points From This Episode:</p>\n\n<ul>\n<li>A brief breakdown of today’s topic
+    and introduction to our special guest, Tyler Young</li>\n<li>We discover Tyler’s
+    background and how he started working in Elixir, as well as how he got into the
+    map business because of his love for Elixir </li>\n<li>We learn about GIS and
+    its history as a system/standard/protocol, and how someone can study GIS </li>\n<li>Find
+    out how mapping is helpful in more ways than just for directions, including climate
+    changes, vacation planning, and more</li>\n<li>Tyler breaks down the common technologies
+    and toolkits for programming with maps </li>\n<li>The specific tools that Felt
+    is using to ingest map data and build the interactive maps </li>\n<li>What common
+    problems arise when developing with maps</li>\n<li><p>Tyler teaches the Elixir
+    Wizards about his tried and true way of decision making with “The McDonald’s option”
+    <br>\n_<br>\n**Links Mentioned in Today’s Episode:</p></li>\n<li><p>Tyler Young
+    on Twitter — <a href=\"https://twitter.com/TylerAYoung\" rel=\"nofollow\">https://twitter.com/TylerAYoung</a></p></li>\n<li><p>Tyler
+    Young on GitHub — <a href=\"https://github.com/s3cur3\" rel=\"nofollow\">https://github.com/s3cur3</a></p></li>\n<li><p>Tyler
+    Young on LinkedIn — <a href=\"https://www.linkedin.com/in/tyler-young-dev/\" rel=\"nofollow\">https://www.linkedin.com/in/tyler-young-dev/</a></p></li>\n<li><p>Felt
+    — <a href=\"https://felt.com/about\" rel=\"nofollow\">https://felt.com/about</a></p></li>\n<li><p>SmartLogic
+    — <a href=\"https://smartlogic.io/\" rel=\"nofollow\">https://smartlogic.io/</a></p></li>\n<li><p>SmartLogic
+    Twitter — <a href=\"https://twitter.com/smartlogic\" rel=\"nofollow\">https://twitter.com/smartlogic</a></p></li>\n</ul>\n
+    \     "
+- title: Kate Rezentes on GenServers at Simplebet
+  slug: s9e2-kate-rezentes-simplebet
+  link: https://smartlogic.io/podcast/elixir-wizards/s9e2-kate-rezentes-simplebet
+  guid: 7bcfea5b-42f1-4dc9-9384-3b37f432a636
+  pubDate: Thu, 06 Oct 2022 06:00:00 -0400
+  pubDateFriendly: October  6, 2022
+  description: "Season 9 is in full swing and we are so excited to welcome Kate Rezentes
+    today to dive into the particulars of GenServers. Kate is a Junior Software Developer
+    at Simplebet, a B2B product development company using machine learning and real-time
+    technology to make every moment of every sporting event a betting opportunity.
+    Tune in today to learn more from today’s special guest, Kate Rezentes!\nKey Points
+    From This Episode:\n A brief breakdown of today’s topic and introduction to our
+    special guest, Kate Rezentes \n We learn about Kate’s background and her long
+    history with programming\nWe discuss how many conferences she’s attended and why
+    ElixirConf has been her favorite (thus far)\n Find out how Kate landed a job while
+    attending ElixirConf\n How GenServers as a subject came to be\nWe get an inside
+    look at Kate’s working experience at Simplebet and her experience as a Junior
+    Engineer in the industry so far \nWhat cases in particular cause the need for
+    a GenServer\nWe discuss where GenServers would be appropriate to use and why\nThe
+    ins and outs of ‘handle calls’ and ‘callbacks’\nThe process of testing a GenServer
+    and data storage_\n**Links Mentioned in Today’s Episode:*\nKate Rezentes on Twitter
+    — https://twitter.com/rezkate\nKate Rezentes on GitHub — https://github.com/KateRezentes\nKate
+    Rezentes on LinkedIn — https://www.linkedin.com/in/kfrezent/\nSimplebet — https://simplebet.io/\nSmartLogic
+    — https://smartlogic.io/\nSmartLogic Twitter — https://twitter.com/smartlogic\n"
+  author: SmartLogic LLC
+  embedUrl: https://fireside.fm/player/v2/IAs5ixts+TZBECxVc
+  enclosure:
+    url: https://aphid.fireside.fm/d/1437767933/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/7bcfea5b-42f1-4dc9-9384-3b37f432a636.mp3
+    length: '46206464'
+    type: audio/mpeg
+  itunes:
+    episodeType: full
+    season: '9'
+    author: SmartLogic LLC
+    subtitle: Season 9 is in full swing and we are so excited to welcome Kate Rezentes
+      today to dive into the particulars of GenServers. Kate is a Junior Software
+      Developer at Simplebet, a B2B product development company using machine learning
+      and real-time technology to make every moment of every sporting event a betting
+      opportunity. Tune in today to learn more from today’s special guest, Kate Rezentes!
+    duration: '48:07'
+    explicit: 'no'
+    keywords: simplebet, genservers, elixir, smartlogic
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
+    summary: "\n        <p>Season 9 is in full swing and we are so excited to welcome
+      Kate Rezentes today to dive into the particulars of GenServers. Kate is a Junior
+      Software Developer at Simplebet, a B2B product development company using machine
+      learning and real-time technology to make every moment of every sporting event
+      a betting opportunity. Tune in today to learn more from today’s special guest,
+      Kate Rezentes!</p>\n\n<p>Key Points From This Episode:</p>\n\n<ul>\n<li> A brief
+      breakdown of today’s topic and introduction to our special guest, Kate Rezentes
+      </li>\n<li> We learn about Kate’s background and her long history with programming</li>\n<li>We
+      discuss how many conferences she’s attended and why ElixirConf has been her
+      favorite (thus far)</li>\n<li> Find out how Kate landed a job while attending
+      ElixirConf</li>\n<li> How GenServers as a subject came to be</li>\n<li>We get
+      an inside look at Kate’s working experience at Simplebet and her experience
+      as a Junior Engineer in the industry so far </li>\n<li>What cases in particular
+      cause the need for a GenServer</li>\n<li>We discuss where GenServers would be
+      appropriate to use and why</li>\n<li>The ins and outs of ‘handle calls’ and
+      ‘callbacks’</li>\n<li>The process of testing a GenServer and data storage_</li>\n</ul>\n\n<p><em>**Links
+      Mentioned in Today’s Episode:</em>*</p>\n\n<ul>\n<li>Kate Rezentes on Twitter
+      — <a href=\"https://twitter.com/rezkate\" rel=\"nofollow\">https://twitter.com/rezkate</a></li>\n<li>Kate
+      Rezentes on GitHub — <a href=\"https://github.com/KateRezentes\" rel=\"nofollow\">https://github.com/KateRezentes</a></li>\n<li>Kate
+      Rezentes on LinkedIn — <a href=\"https://www.linkedin.com/in/kfrezent/\" rel=\"nofollow\">https://www.linkedin.com/in/kfrezent/</a></li>\n<li>Simplebet
+      — <a href=\"https://simplebet.io/\" rel=\"nofollow\">https://simplebet.io/</a></li>\n<li>SmartLogic
+      — <a href=\"https://smartlogic.io/\" rel=\"nofollow\">https://smartlogic.io/</a></li>\n<li>SmartLogic
+      Twitter — <a href=\"https://twitter.com/smartlogic\" rel=\"nofollow\">https://twitter.com/smartlogic</a></li>\n</ul>\n
+      \     "
+  contentEncoded: "\n        <p>Season 9 is in full swing and we are so excited to
+    welcome Kate Rezentes today to dive into the particulars of GenServers. Kate is
+    a Junior Software Developer at Simplebet, a B2B product development company using
+    machine learning and real-time technology to make every moment of every sporting
+    event a betting opportunity. Tune in today to learn more from today’s special
+    guest, Kate Rezentes!</p>\n\n<p>Key Points From This Episode:</p>\n\n<ul>\n<li>
+    A brief breakdown of today’s topic and introduction to our special guest, Kate
+    Rezentes </li>\n<li> We learn about Kate’s background and her long history with
+    programming</li>\n<li>We discuss how many conferences she’s attended and why ElixirConf
+    has been her favorite (thus far)</li>\n<li> Find out how Kate landed a job while
+    attending ElixirConf</li>\n<li> How GenServers as a subject came to be</li>\n<li>We
+    get an inside look at Kate’s working experience at Simplebet and her experience
+    as a Junior Engineer in the industry so far </li>\n<li>What cases in particular
+    cause the need for a GenServer</li>\n<li>We discuss where GenServers would be
+    appropriate to use and why</li>\n<li>The ins and outs of ‘handle calls’ and ‘callbacks’</li>\n<li>The
+    process of testing a GenServer and data storage_</li>\n</ul>\n\n<p><em>**Links
+    Mentioned in Today’s Episode:</em>*</p>\n\n<ul>\n<li>Kate Rezentes on Twitter
+    — <a href=\"https://twitter.com/rezkate\" rel=\"nofollow\">https://twitter.com/rezkate</a></li>\n<li>Kate
+    Rezentes on GitHub — <a href=\"https://github.com/KateRezentes\" rel=\"nofollow\">https://github.com/KateRezentes</a></li>\n<li>Kate
+    Rezentes on LinkedIn — <a href=\"https://www.linkedin.com/in/kfrezent/\" rel=\"nofollow\">https://www.linkedin.com/in/kfrezent/</a></li>\n<li>Simplebet
+    — <a href=\"https://simplebet.io/\" rel=\"nofollow\">https://simplebet.io/</a></li>\n<li>SmartLogic
+    — <a href=\"https://smartlogic.io/\" rel=\"nofollow\">https://smartlogic.io/</a></li>\n<li>SmartLogic
+    Twitter — <a href=\"https://twitter.com/smartlogic\" rel=\"nofollow\">https://twitter.com/smartlogic</a></li>\n</ul>\n
+    \     "
+- title: Dave Lucia on Observability at Bitfo
+  slug: s9e1-dave-lucia-bitfo
+  link: https://smartlogic.io/podcast/elixir-wizards/s9e1-dave-lucia-bitfo
+  guid: ccdb0e5d-3009-44db-9573-d5a5a12696eb
+  pubDate: Thu, 29 Sep 2022 03:00:00 -0400
+  pubDateFriendly: September 29, 2022
+  description: |
+    Welcome to our first episode of Season 9 Elixir Wizards, Parsing the Particulars. A show focused on conversations with software developers from around the world on the Elixir language and other modern web technologies. Today, we are joined by Dave Lucia, Chief Technology Officer at Bitfo, a cryptocurrency media company building educational content for people who are interested in cryptocurrency. Dave is active in the Elixir community and in the past has spoken at Code BEAM SF, ElixirConf, RabbitMQ Summit, and has written several blog posts which can be found at davelucia.com. In today’s episode we find out more about Dave’s professional background and dive into the particulars of observability. Tune in today to learn more from today’s special guest, Dave Lucia!
+    Key Points From This Episode:
+    A brief breakdown of today’s topic and introduction to our special guest, Dave Lucia
+    We find out about Bitfo and what services they offer
+    We discuss Dave’s blog post on observability
+    Find out how Dave wrote the blog post because he saw a gap at his company
+    How Sundi proofread Dave’s blog post and realized her lack of knowledge on observability
+    The most common mistake teams or engineers make when it comes to observability
+    We peel back the layers on what telemetry is
+    What the difference between telemetry and OpenTelemetry is
+    How to choose which tool is right when it comes to better observability
+    *The breakdown of the uses for observability telemetry
+    *When and why would we use OpenTelemtry vs basic observability
+    *What languages Dave started in before he was working in Elixir
+    *How Elixir lends better for observability
+    *Where to start if you want to implement basic observability for someone who has no experience with it
+    *Dave answers the question, “can you go too far with observability?”
+    *We discuss Livebook and what exciting things it will bring for the future
+    *Most importantly, Dave explains why pineapples are important to him
+    **Links Mentioned in Today’s Episode:
+    Dave’s blog post on Observability: https://davelucia.com/blog/observing-elixir-with-lightstep
+    Dave Lucia on Twitter — https://twitter.com/davydog187
+    Dave Lucia on GitHub — https://github.com/davydog187
+    Dave Lucia on LinkedIn — https://www.linkedin.com/in/david-lucia-a395441b/
+    Bitfo — https://www.bitfo.com/
+    SmartLogic — https://smartlogic.io/
+  author: SmartLogic LLC
+  embedUrl: https://fireside.fm/player/v2/IAs5ixts+87YV43bE
+  enclosure:
+    url: https://aphid.fireside.fm/d/1437767933/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/ccdb0e5d-3009-44db-9573-d5a5a12696eb.mp3
+    length: '74289426'
+    type: audio/mpeg
+  itunes:
+    episodeType: full
+    season: '9'
+    author: SmartLogic LLC
+    subtitle: ''
+    duration: '51:35'
+    explicit: 'no'
+    keywords: bitfo, crypto, elixir, observability
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
+    summary: "\n        <p>Welcome to our first episode of Season 9 Elixir Wizards,
+      Parsing the Particulars. A show focused on conversations with software developers
+      from around the world on the Elixir language and other modern web technologies.
+      Today, we are joined by Dave Lucia, Chief Technology Officer at Bitfo, a cryptocurrency
+      media company building educational content for people who are interested in
+      cryptocurrency. Dave is active in the Elixir community and in the past has spoken
+      at Code BEAM SF, ElixirConf, RabbitMQ Summit, and has written several blog posts
+      which can be found at davelucia.com. In today’s episode we find out more about
+      Dave’s professional background and dive into the particulars of observability.
+      Tune in today to learn more from today’s special guest, Dave Lucia!</p>\n\n<p>Key
+      Points From This Episode:</p>\n\n<ul>\n<li>A brief breakdown of today’s topic
+      and introduction to our special guest, Dave Lucia</li>\n<li>We find out about
+      Bitfo and what services they offer</li>\n<li>We discuss Dave’s blog post on
+      observability</li>\n<li>Find out how Dave wrote the blog post because he saw
+      a gap at his company</li>\n<li>How Sundi proofread Dave’s blog post and realized
+      her lack of knowledge on observability</li>\n<li>The most common mistake teams
+      or engineers make when it comes to observability</li>\n<li>We peel back the
+      layers on what telemetry is</li>\n<li>What the difference between telemetry
+      and OpenTelemetry is</li>\n<li>How to choose which tool is right when it comes
+      to better observability\n*The breakdown of the uses for observability telemetry\n*When
+      and why would we use OpenTelemtry vs basic observability\n*What languages Dave
+      started in before he was working in Elixir\n*How Elixir lends better for observability\n*Where
+      to start if you want to implement basic observability for someone who has no
+      experience with it\n*Dave answers the question, “can you go too far with observability?”\n*We
+      discuss Livebook and what exciting things it will bring for the future\n*Most
+      importantly, Dave explains why pineapples are important to him</li>\n</ul>\n\n<p>**Links
+      Mentioned in Today’s Episode:</p>\n\n<ul>\n<li>Dave’s blog post on Observability:
+      <a href=\"https://davelucia.com/blog/observing-elixir-with-lightstep\" rel=\"nofollow\">https://davelucia.com/blog/observing-elixir-with-lightstep</a></li>\n<li>Dave
+      Lucia on Twitter — <a href=\"https://twitter.com/davydog187\" rel=\"nofollow\">https://twitter.com/davydog187</a></li>\n<li>Dave
+      Lucia on GitHub — <a href=\"https://github.com/davydog187\" rel=\"nofollow\">https://github.com/davydog187</a></li>\n<li>Dave
+      Lucia on LinkedIn — <a href=\"https://www.linkedin.com/in/david-lucia-a395441b/\"
+      rel=\"nofollow\">https://www.linkedin.com/in/david-lucia-a395441b/</a></li>\n<li>Bitfo
+      — <a href=\"https://www.bitfo.com/\" rel=\"nofollow\">https://www.bitfo.com/</a></li>\n<li>SmartLogic
+      — <a href=\"https://smartlogic.io/\" rel=\"nofollow\">https://smartlogic.io/</a></li>\n</ul><p>Links:</p><ul><li><a
+      href=\"https://open.spotify.com/episode/3RmFXCjuVIsT1DqzqSZgAv?si=1c5d7a3171164223\"
+      title=\"Spotify\" rel=\"nofollow\">Spotify</a></li></ul>\n      "
+  contentEncoded: "\n        <p>Welcome to our first episode of Season 9 Elixir Wizards,
+    Parsing the Particulars. A show focused on conversations with software developers
+    from around the world on the Elixir language and other modern web technologies.
+    Today, we are joined by Dave Lucia, Chief Technology Officer at Bitfo, a cryptocurrency
+    media company building educational content for people who are interested in cryptocurrency.
+    Dave is active in the Elixir community and in the past has spoken at Code BEAM
+    SF, ElixirConf, RabbitMQ Summit, and has written several blog posts which can
+    be found at davelucia.com. In today’s episode we find out more about Dave’s professional
+    background and dive into the particulars of observability. Tune in today to learn
+    more from today’s special guest, Dave Lucia!</p>\n\n<p>Key Points From This Episode:</p>\n\n<ul>\n<li>A
+    brief breakdown of today’s topic and introduction to our special guest, Dave Lucia</li>\n<li>We
+    find out about Bitfo and what services they offer</li>\n<li>We discuss Dave’s
+    blog post on observability</li>\n<li>Find out how Dave wrote the blog post because
+    he saw a gap at his company</li>\n<li>How Sundi proofread Dave’s blog post and
+    realized her lack of knowledge on observability</li>\n<li>The most common mistake
+    teams or engineers make when it comes to observability</li>\n<li>We peel back
+    the layers on what telemetry is</li>\n<li>What the difference between telemetry
+    and OpenTelemetry is</li>\n<li>How to choose which tool is right when it comes
+    to better observability\n*The breakdown of the uses for observability telemetry\n*When
+    and why would we use OpenTelemtry vs basic observability\n*What languages Dave
+    started in before he was working in Elixir\n*How Elixir lends better for observability\n*Where
+    to start if you want to implement basic observability for someone who has no experience
+    with it\n*Dave answers the question, “can you go too far with observability?”\n*We
+    discuss Livebook and what exciting things it will bring for the future\n*Most
+    importantly, Dave explains why pineapples are important to him</li>\n</ul>\n\n<p>**Links
+    Mentioned in Today’s Episode:</p>\n\n<ul>\n<li>Dave’s blog post on Observability:
+    <a href=\"https://davelucia.com/blog/observing-elixir-with-lightstep\" rel=\"nofollow\">https://davelucia.com/blog/observing-elixir-with-lightstep</a></li>\n<li>Dave
+    Lucia on Twitter — <a href=\"https://twitter.com/davydog187\" rel=\"nofollow\">https://twitter.com/davydog187</a></li>\n<li>Dave
+    Lucia on GitHub — <a href=\"https://github.com/davydog187\" rel=\"nofollow\">https://github.com/davydog187</a></li>\n<li>Dave
+    Lucia on LinkedIn — <a href=\"https://www.linkedin.com/in/david-lucia-a395441b/\"
+    rel=\"nofollow\">https://www.linkedin.com/in/david-lucia-a395441b/</a></li>\n<li>Bitfo
+    — <a href=\"https://www.bitfo.com/\" rel=\"nofollow\">https://www.bitfo.com/</a></li>\n<li>SmartLogic
+    — <a href=\"https://smartlogic.io/\" rel=\"nofollow\">https://smartlogic.io/</a></li>\n</ul><p>Links:</p><ul><li><a
+    href=\"https://open.spotify.com/episode/3RmFXCjuVIsT1DqzqSZgAv?si=1c5d7a3171164223\"
+    title=\"Spotify\" rel=\"nofollow\">Spotify</a></li></ul>\n      "
 - title: We're baaaack! Season 9 Teaser
   slug: teasers9
   link: https://smartlogic.io/podcast/elixir-wizards/teasers9
   guid: e16cbd56-185c-4abf-a193-52a629580bc7
   pubDate: Thu, 22 Sep 2022 00:00:00 -0400
   pubDateFriendly: September 22, 2022
-  description: ''
+  description: "Hey everyone, Season 9 of Elixir Wizards is back! This season's theme
+    is Parsing the Particulars, where we dive into particular subjects with our guests.
+    Your returning hosts this season are Sundi, Owen and Dan! And we are excited to
+    announce that we have a new host joining the show - Bilal Hankins! Bilal is a
+    Software Developer at SmartLogic and is super excited to join us this season.
+    \nSome of this season's guests include Dave Lucia, CTO at Bitfo, Tyler Young,
+    Senior Software Developer at Felt, and Kate Rezentes, Junior Developer at SimpleBet.
+    Can't wait to see you there!\nSmartLogic — https://smartlogic.io/ \nSmartLogic
+    on Twitter — https://twitter.com/smartlogic\nSmartLogic on LinkedIn — https://www.linkedin.com/company/smartlogic-io/\nSmartLogic
+    on Facebook — https://www.facebook.com/smartlogic/\nBilal Hankins on LinkedIn
+    — https://www.linkedin.com/in/hankins-bilal/\nSundi Myint on LinkedIn — https://www.linkedin.com/in/sundimyint/\nOwen
+    Bickford on LinkedIn — https://www.linkedin.com/in/owen-bickford-8b6b1523a/\n"
   author: SmartLogic LLC
   embedUrl: https://fireside.fm/player/v2/IAs5ixts+TDzrU9qw
   enclosure:
@@ -126,9 +440,42 @@
     duration: '1:07'
     explicit: 'no'
     keywords: 'elixir, tech, code '
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/e/e16cbd56-185c-4abf-a193-52a629580bc7/cover.jpg?v=1
-    summary: "\n        \n      "
-  contentEncoded: "\n        \n      "
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
+    summary: "\n        <p>Hey everyone, Season 9 of Elixir Wizards is back! This
+      season&#39;s theme is Parsing the Particulars, where we dive into particular
+      subjects with our guests. Your returning hosts this season are Sundi, Owen and
+      Dan! And we are excited to announce that we have a new host joining the show
+      - Bilal Hankins! Bilal is a Software Developer at SmartLogic and is super excited
+      to join us this season. </p>\n\n<p>Some of this season&#39;s guests include
+      Dave Lucia, CTO at Bitfo, Tyler Young, Senior Software Developer at Felt, and
+      Kate Rezentes, Junior Developer at SimpleBet. Can&#39;t wait to see you there!</p>\n\n<p>SmartLogic
+      — <a href=\"https://smartlogic.io/\" rel=\"nofollow\">https://smartlogic.io/</a>
+      <br>\nSmartLogic on Twitter — <a href=\"https://twitter.com/smartlogic\" rel=\"nofollow\">https://twitter.com/smartlogic</a><br>\nSmartLogic
+      on LinkedIn — <a href=\"https://www.linkedin.com/company/smartlogic-io/\" rel=\"nofollow\">https://www.linkedin.com/company/smartlogic-io/</a><br>\nSmartLogic
+      on Facebook — <a href=\"https://www.facebook.com/smartlogic/\" rel=\"nofollow\">https://www.facebook.com/smartlogic/</a><br>\nBilal
+      Hankins on LinkedIn — <a href=\"https://www.linkedin.com/in/hankins-bilal/\"
+      rel=\"nofollow\">https://www.linkedin.com/in/hankins-bilal/</a><br>\nSundi Myint
+      on LinkedIn — <a href=\"https://www.linkedin.com/in/sundimyint/\" rel=\"nofollow\">https://www.linkedin.com/in/sundimyint/</a><br>\nOwen
+      Bickford on LinkedIn — <a href=\"https://www.linkedin.com/in/owen-bickford-8b6b1523a/\"
+      rel=\"nofollow\">https://www.linkedin.com/in/owen-bickford-8b6b1523a/</a></p>\n
+      \     "
+  contentEncoded: "\n        <p>Hey everyone, Season 9 of Elixir Wizards is back!
+    This season&#39;s theme is Parsing the Particulars, where we dive into particular
+    subjects with our guests. Your returning hosts this season are Sundi, Owen and
+    Dan! And we are excited to announce that we have a new host joining the show -
+    Bilal Hankins! Bilal is a Software Developer at SmartLogic and is super excited
+    to join us this season. </p>\n\n<p>Some of this season&#39;s guests include Dave
+    Lucia, CTO at Bitfo, Tyler Young, Senior Software Developer at Felt, and Kate
+    Rezentes, Junior Developer at SimpleBet. Can&#39;t wait to see you there!</p>\n\n<p>SmartLogic
+    — <a href=\"https://smartlogic.io/\" rel=\"nofollow\">https://smartlogic.io/</a>
+    <br>\nSmartLogic on Twitter — <a href=\"https://twitter.com/smartlogic\" rel=\"nofollow\">https://twitter.com/smartlogic</a><br>\nSmartLogic
+    on LinkedIn — <a href=\"https://www.linkedin.com/company/smartlogic-io/\" rel=\"nofollow\">https://www.linkedin.com/company/smartlogic-io/</a><br>\nSmartLogic
+    on Facebook — <a href=\"https://www.facebook.com/smartlogic/\" rel=\"nofollow\">https://www.facebook.com/smartlogic/</a><br>\nBilal
+    Hankins on LinkedIn — <a href=\"https://www.linkedin.com/in/hankins-bilal/\" rel=\"nofollow\">https://www.linkedin.com/in/hankins-bilal/</a><br>\nSundi
+    Myint on LinkedIn — <a href=\"https://www.linkedin.com/in/sundimyint/\" rel=\"nofollow\">https://www.linkedin.com/in/sundimyint/</a><br>\nOwen
+    Bickford on LinkedIn — <a href=\"https://www.linkedin.com/in/owen-bickford-8b6b1523a/\"
+    rel=\"nofollow\">https://www.linkedin.com/in/owen-bickford-8b6b1523a/</a></p>\n
+    \     "
 - title: Looking back on Season 8 with Sundi, Owen & Dan
   slug: s8e12-finale
   link: https://smartlogic.io/podcast/elixir-wizards/s8e12-finale
@@ -173,7 +520,7 @@
     duration: '38:23'
     explicit: 'no'
     keywords: ''
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/2/2cd157b4-8fcd-4025-9d56-76a10fb61903/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>It’s the season finale show! Can you believe it? Join us
       this week as Sundi, Owen, and Dan take a look back at this season of Elixir
       Wizards! You’ll hear their discussion about favorite moments over the season
@@ -260,7 +607,7 @@
     duration: '29:11'
     explicit: 'no'
     keywords: ''
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/3/3d022fd3-b8f1-41da-97ac-8e9b5784bfa3/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>This week on Elixir Wizards we’re joined by Nathan Retta,
       Senior Software Engineer from Android at DoorDash. We learn about Nathan’s background;
       his experience having a degree in Chemical Engineering and working in Oil and
@@ -312,7 +659,7 @@
     duration: '44:41'
     explicit: 'no'
     keywords: ''
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/a/acc26d2b-07e6-4dad-8ef5-e78780d17650/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Welcome to this week’s episode of Elixir Wizards, with
       our special guest, Cara Mitchell of Pepsi Co. Today we speak with Cara about
       her career journey that led to her living in the lower East Side of New York
@@ -389,7 +736,7 @@
     duration: '42:48'
     explicit: 'no'
     keywords: ''
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/9/9114fce2-a423-4c1d-9ca6-c5ff2098dd34/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Joining us today on Elixir Wizards is Catalina Astengo,
       Staff Software Engineer at Nav Inc. We chat with Catalina about how she went
       from working as a process engineer in a mine to a software engineer in beautiful
@@ -541,7 +888,7 @@
     duration: '45:35'
     explicit: 'no'
     keywords: ''
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/7/7a1f4173-df13-4237-9d32-e862b6512a16/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Welcome to another episode of Elixir Wizards, a show focused
       on conversations with software developers from around the world on the Elixir
       language and other modern web technologies. In today’s episode, we speak with
@@ -727,7 +1074,7 @@
     duration: '43:42'
     explicit: 'no'
     keywords: ''
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/9/942f6a18-066a-4996-b3f8-9b0712959574/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>A superpower of software development is teaching our code
       to teach us what’s happening. This is observability, and it’s why Jessica Kerr
       works at Honeycomb, where she is a Developer Advocate. After twenty years as
@@ -903,7 +1250,7 @@
     duration: '42:58'
     explicit: 'no'
     keywords: ''
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/c/c1e61882-d69a-47d8-af8b-a1a1b3f33708/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Welcome back to another episode of Elixir Wizards. Today,
       we chat with Digit, a talented software engineer currently based at SmartRent.
       He became aware of the company when he started trying to modify his smart home
@@ -1049,7 +1396,7 @@
     duration: '45:20'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/2/23a28e9b-417e-4841-9b86-addd0247ce4e/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Joining us in conversation today is Nathan Willson all
       the way from Tokyo, Japan. Listeners will learn about the polyglot landscape
       he works in from Japan, why he believes knowing a language, and mastering it,
@@ -1183,7 +1530,7 @@
     duration: '43:31'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/3/32849026-ad26-4b84-9a89-316306f6e3c1/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>This week we are joined by Sanne Kalkman, former teacher
       turned software engineer. Currently, Sanne works at CodeSandbox, where she&#39;s
       one of two Elixir developers responsible for the backend. When she&#39;s not
@@ -1343,7 +1690,7 @@
     duration: '1:00:36'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/c/c1436a7a-59b9-402a-970c-f87791f275e1/cover.jpg?v=2
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>This double guest episode features Cassidy Williams, Head
       of Developer Experience and Education and Tobi Pfeiffer, Staff Engineer from
       Remote. This fast growing Elixir company provides HR support to clients who
@@ -1521,7 +1868,7 @@
     duration: '48:07'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/9/95a396ef-84bd-43e0-b0ae-dc8276917eb9/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Today’s guest is Devon Estes, who leads the third-party
       integration team at Remote, a company that uses technology to make it easier
       for other companies to hire remote employees (not contractors, actual employees)
@@ -1647,7 +1994,7 @@
     duration: '48:47'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/f/f4a94090-3527-4b5f-924e-beb55f9688c5/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Welcome to the new season of Elixir Wizards: Elixir in
       a Polyglot Environment. To get things going on this exciting and intriguing
       subject we are very happy to welcome Miguel Cobá! Miguel currently works at
@@ -1789,7 +2136,7 @@
     duration: '56:55'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/8/8ddde7c8-d4df-4b6b-88dd-7ac7796534c1/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Welcome to the Season 7 finale! Today, we are joined by
       Todd Resudek, Staff Engineer at Jackpocket, to reflect on the past season and
       speak about the impact of Elixir, as well as a variety of other topics almost
@@ -1940,7 +2287,7 @@
     duration: '45:33'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/d/d64b67ed-770e-44c1-8032-b2666cc84d48/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>This week we welcome Arthi Radhakrishnan back to the show
       to discuss how Elixir and her career more broadly have shaped her perspectives
       on learning. Arthi first got into programming as a child growing up in the Bay
@@ -2077,7 +2424,7 @@
     duration: '51:20'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/a/a9b73218-2d0c-4a6f-9bba-93d5c355db7a/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Today we welcome software engineer Meryl Dakin to the show,
       who is currently employed by Knock. Meryl is here to help us continue our exploration
       of this season&#39;s theme of the impact of Elixir, and we get to hear about
@@ -2244,7 +2591,7 @@
     duration: '46:05'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/6/66261581-0dd2-4380-8280-495736a41540/cover.jpg?v=2
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>We are very excited to welcome Brooklyn Zelenka back to
       the podcast to talk about her work at Fission and the ever-expanding frontier
       of edge computing! Brooklyn is a co-founder and CTO at Fission and she gives
@@ -2405,7 +2752,7 @@
     duration: '50:42'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/b/bb8d89d6-4176-4414-b0fe-8e569cff9408/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>We are always excited to have conversations about the growth
       of the Elixir community, and today we go truly global, welcoming Sigu Magwa
       to the podcast, who hails from Kenya! Sigu is currently traveling in the US
@@ -2561,7 +2908,7 @@
     duration: '56:10'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/c/c628b216-0cf4-431f-b430-377ad40bf4ff/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Brooklin Myers is on a quest to change the perception that
       Elixir is difficult to get into and we are so grateful to have him as a guest
       on the show today. Aside from being a passionate programmer, Brooklin spends
@@ -2711,7 +3058,7 @@
     duration: '45:17'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/0/03563586-ac91-4c9e-a6ec-f7a91318d2b7/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>It is important to us that the Elixir community keeps thriving,
       and one of the best ways to ensure this is by lowering the barrier to entry
       as much as possible. Livebook is helping to achieve this aim, and today we are
@@ -2885,7 +3232,7 @@
     duration: '42:11'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/4/496000a0-b38c-4ab6-96f8-a0948d8c6d40/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Today on the show we are grateful to get the chance to
       speak with Yiming Chen from Tubi, where we hear all about how he likes to use
       Elixir and the contributions he has made to the community. We begin as always
@@ -3049,7 +3396,7 @@
     duration: '47:53'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/5/5c3a89b0-b7f6-4b83-aebb-af04520dba3e/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Today we are joined by programmer, professor, educator,
       and podcaster, Adolfo Neto! We have a fascinating conversation that continues
       our exploration of the theme of the impact of Elixir, hearing from Adolfo about
@@ -3213,7 +3560,7 @@
     duration: '48:52'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/e/e7dec128-99fe-4b5f-9f1c-0844b6424558/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>As we continue this season of the podcast, focusing on
       the impact of Elixir, we are joined by Florian Kraft, all the way from Berlin,
       Germany! Florian works as a software engineer at Contentful, and has a number
@@ -3390,7 +3737,7 @@
     duration: '47:57'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/1/196446c8-44e8-4c34-86c8-a688bfb3f706/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Today’s guest is Angel Jose, a Software Engineer Manager
       at Cars.com with a passion for product and the customer experience. Angel played
       a key role in completely re-platforming Cars.com via Elixir, Phoenix, and other
@@ -3530,7 +3877,7 @@
     duration: '58:47'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/6/6610fc7c-e295-43f4-b542-40847c96f358/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>As we kick off our new, seventh season of the Elixir Wizards
       podcast, we wanted to introduce our theme of the impact of Elixir by having
       a simple chat between our panel and foregoing our usual guest format. As fans
@@ -3654,7 +4001,7 @@
     duration: '57:56'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/5/5bcca27a-dc98-4584-a152-84f4b04ee0d5/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>We have reached the final episode of our season, and as
       we wrap up our exploration of BEAM magic, we are joined by Amos King, whose
       tweet was the inspiration behind this season&#39;s focus! We&#39;ve had such
@@ -3801,7 +4148,7 @@
     duration: '38:30'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/3/332edbe7-b497-4b63-a474-8d468123d586/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>This episode serves as a round-up of some of the special
       mini-features we have recorded throughout Season 6, where we&#39;ll hear from
       Tyler Clemens, Elom Amouzou, Elise Navarro, and Jeremy Neal about their work
@@ -3976,7 +4323,7 @@
     duration: '44:54'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/1/1487b980-5611-4fbc-9c58-7b4508ebefa9/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Joining us on the show today is Quinn Wilton, and we have
       a wonderful conversation with our guest about her journey with Elixir, unusual
       path into programming, and her wide appreciation for different languages! We
@@ -4129,7 +4476,7 @@
     duration: '46:34'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/5/5e1ccc21-8727-4ae4-8921-ae296f46cff7/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>While NIFs provide a great way to interface with native
       code in the BEAM machine, the process can also be rather error-prone. Thankfully,
       since Isaac Yonemoto built Zigler, things have become a lot simpler, and he
@@ -4285,7 +4632,7 @@
     duration: '50:13'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/f/ff944923-7612-4245-b9b0-d9217e878b0b/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Today we are so excited to share a conversation with Maxim
       Fedorov, who is the Core Infrastructure Lead at communications giant, WhatsApp!
       In our chat, Maxim offers such interesting insight and wisdom from a long career
@@ -4455,7 +4802,7 @@
     duration: '48:08'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/4/49a8c965-5f19-4aba-9cd7-6b59acc7188b/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Some of you may recognize Chelsea Troy from her popular
       blog of the same name or as a keynote speaker for the March 2021 Code BEAM conference.
       Chelsea is an instructor in the Master&#39;s Program in Computer Science at
@@ -4631,7 +4978,7 @@
     duration: '56:18'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/3/3cc0b619-ef6a-48ed-a0d6-8566f26ed0a9/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>While we can think of many reasons why we love Elixir,
       the community could always benefit from a more lively conversation around testing.
       It was with this in mind that Jeffrey Matthias and Andrea Leopardi decided to
@@ -4822,7 +5169,7 @@
     duration: '46:33'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/3/3c07dbc2-eadc-48b9-9136-7decec7a0f57/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Joining us for this episode of Elixir Wizards is the vastly
       experienced and well-traveled Francesco Cesarini! Francesco is the founder of
       Erlang Solutions and we are so lucky to have him here on the show to talk about
@@ -5035,7 +5382,7 @@
     duration: '54:11'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/9/95a7bb65-24d3-4155-bd40-9a4b4a94fbbb/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Today we have some extra BEAM magic for all of you! Joining
       us on the show is Chris Miller, who currently works as an Associate Software
       Engineer at Corvus Insurance. We get into a great conversation with Chris about
@@ -5226,7 +5573,7 @@
     duration: '50:21'
     explicit: 'no'
     keywords: ''
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/9/943755c0-4bf5-4c89-949c-44406ea58584/cover.jpg?v=3
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>While there is magic to be found in many frameworks, having
       too much going on under the hood without you being able to control it is not
       for everybody. Today we invite Parker and Shannon Selbert to speak about their
@@ -5408,7 +5755,7 @@
     duration: '1:00:41'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/f/f1486983-1421-45be-87ae-99a0a56ec848/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Today we are joined by the Vice President of Engineering
       at Corvus Insurance, Erik Person! Erik continues our journey into the magic
       of the BEAM, our season-long theme for the Elixir Wizards Podcast, and we get
@@ -5612,7 +5959,7 @@
     duration: '49:38'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/1/10914181-66e0-4200-b6c8-260bee7e32bd/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Welcome to a brand-spanking-new season of Elixir Wizards!
       This time around we will be focussing on the magic of the BEAM, so get ready
       for an exciting journey into new territories filled with mystery and power!
@@ -5813,7 +6160,7 @@
     duration: '1:01:39'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/1/12f603e4-7d53-4e83-baed-33e436cbf102/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Season 5 ends with a bang as we welcome back Sean Lewis,
       Anna Neyzber, and René Föhring onto the show to share their journey on getting
       their companies and teams to adopt Elixir. We open our conversation with each
@@ -5999,7 +6346,7 @@
     duration: '47:38'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/2/2bb38486-078c-44b5-a40c-b2c71a50d210/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>The fields of data science and machine learning are moving
       ever faster. Jenn Gamble has her finger on the pulse and has become an industry
       expert with a wealth of experience to her name. As today’s guest, she dives
@@ -6167,7 +6514,7 @@
     duration: '43:27'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/d/d761c5dd-b1bf-4062-a4e0-fe20d7c85e7f/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Many organizations take an incremental approach when adopting
       Elixir, preferring to pick up its nuances by using it to work on non-essential
       projects. But not Change.org. Today we speak with Change.org Director of Engineering
@@ -6354,7 +6701,7 @@
     duration: '48:20'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/9/9470edd5-3447-4d40-9f5d-aaba34126ae3/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>As users increasingly demand interactivity from their web
       experiences, Phoenix LiveView is becoming the dominant way of writing interactive
       Elixir applications without a loss to reliability. Today we welcome back an
@@ -6562,7 +6909,7 @@
     duration: '50:45'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/9/97fc73f8-1e61-447f-953f-99d2580f1476/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>With the prevalence of at-home learning, teachers have
       to compete for student attention against numerous screen-based activities. Today
       we speak with engineering lead Shaun Robinson and Elixir developer Toran Billups
@@ -6774,7 +7121,7 @@
     duration: '59:23'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/1/1b9ca1de-dc95-49fa-885b-4e6093d52055/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>ClusterTruck, a master of vertical integration, is rewriting
       the method of end-to-end food delivery and ghost kitchens. Today we speak with
       ClusterTruck Product VP Brian Howenstein to find out more about his journey
@@ -6981,7 +7328,7 @@
     duration: '55:46'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/b/bc908c5d-f422-4fc4-809b-ec4f4b051d3a/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Building a successful development company requires having
       a leader with technical know-how and excellent management skills. Today we speak
       with SmartLogic President and Founder Yair Flicker about his company’s origin
@@ -7145,7 +7492,7 @@
     duration: '48:25'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/d/d3843a34-8180-4e29-ae31-ab4d2da8379b/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Despite its welcoming character, the Elixir community struggles
       with diversity; as the 2020 ElixirConf community survey shows, only 2% of Elixirists
       are women. Today we speak with Blinker software engineer Alexandra Chakeres
@@ -7316,7 +7663,7 @@
     duration: '53:12'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/1/1752ae0e-feb0-4606-b3b0-97f70e29e3de/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>In this episode we continue our conversation about adopting
       Elixir, this time with Matt Nowack and Jake Heinz from Discord, hearing them
       get into the features of Elixir that make it a great fit for building a real-time
@@ -7495,7 +7842,7 @@
     duration: '33:57'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/6/6475cfad-49d7-498d-a06a-c9af4a82e710/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Welcome back to the Elixir Wizards podcast! In this episode,
       we will be continuing our conversation on the theme of adopting elixir, and
       our great guest for today is Jason Axelson! Jason is a back-end developer for
@@ -7674,7 +8021,7 @@
     duration: '38:33'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/6/6d2c98f6-1ba5-4003-8e4a-d98265dccd91/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Anyone who has written software for the travel industry
       can tell you that it is in desperate need of innovation — shockingly many of
       their cobwebbed systems were built in the 70s. Today we speak with Duffel CEO
@@ -7845,7 +8192,7 @@
     duration: '38:57'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/a/a15c1f14-3ae4-4a02-a642-a03ab3e11660/cover.jpg?v=2
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>To beat out their competitors, startups need to code quickly,
       simply, and in a language that attracts top engineers. Enter Elixir. Today we
       speak with Shawn Vo, Axle Payments Co-Founder and CTO, about his journey with
@@ -8037,7 +8384,7 @@
     duration: '47:20'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/6/6e5cd223-dc2c-42ee-9c40-d7e778b4ee9b/cover.jpg?v=2
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Today we sit down with Erlanger Viktória Fördős, who talks
       with us about Erlang and how it is used at Cisco. We open the show by finding
       out about Viki’s background in coding and her unorthodox entry into the field.
@@ -8242,7 +8589,7 @@
     duration: '37:27'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/4/4653eb7c-8637-447c-8ead-a6fe53e5c3cc/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Today’s guest is Simon Glenn-Gregg, News Engineer at The
       Washington Post. He joins us to talk about using Elixir to build a prototype
       for a platform the news house recently implemented to visualize the results
@@ -8456,7 +8803,7 @@
     duration: '53:09'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/4/41c6ea5d-4915-4a6e-9795-3e2a9b57aa72/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>The culture of your programming community directly impacts
       your professional success. As Thunderbolt Labs Founder Randall Thomas explains
       in this episode, a community that practices openness and which warmly welcomes
@@ -8676,7 +9023,7 @@
     duration: '56:34'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/4/4a9a2637-46ff-42d5-af60-6c46bbf9c3fa/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Welcome back to Elixir Wizards, season five, episode one!
       The theme for this season is ‘Adopting Elixir’, and for today’s show the team
       at Elixir Outlaws play host! Chris Keathley, Amos King, and Anna Neyzberg give
@@ -8865,7 +9212,7 @@
     duration: '59:12'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/8/8cbeff8e-7468-4da6-a117-7e0a1f94d653/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>To close off this season and conclude our deep dive into
       system and application architecture, today’s episode is a special panel discussion
       on a topic that has provoked a mix of answers that range from the controversial
@@ -9074,7 +9421,7 @@
     duration: '35:16'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/6/6cb1796f-017c-4f06-bd10-9cbf85fff404/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Even with the most programming experience in the world,
       coding still involves a lot of trial and error. People getting started in the
       industry should not become bogged down by failure. Because in the end, it’s
@@ -9257,7 +9604,7 @@
     duration: '48:36'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/b/b59ac59d-736e-4581-b0c0-e04adeb1ba91/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>There is no difference between architecture and design.
       It&#39;s all engineering and creating a distinction between the two is a way
       for someone to get paid more and have a different title. That hot take comes
@@ -9454,7 +9801,7 @@
     duration: '48:24'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/a/a61dcf3a-a8e5-45c7-a648-6994628ce9ec/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Imagine being hired into a rocketship startup using Elixir
       as its primary language. And all this, straight out of college. Today, we speak
       with systems software engineer, Lizzie Paquette who works at Brex, the aforementioned
@@ -9711,7 +10058,7 @@
     duration: '49:09'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/7/7070efa5-519a-4d9b-ac5a-75cfc1882a31/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Building a sophisticated AI that can evolve to fit our
       vast and diverse needs is a Herculean challenge. Today we speak with senior
       engineer Eric Steen about Automata, his experimental Elixir project that uses
@@ -9971,7 +10318,7 @@
     duration: '42:29'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/4/441f7029-d8ab-4494-aa7b-cfb08e4ade23/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>According to an ancient myth, the world rests on the back
       of a turtle. And what does that turtle stand on? Another turtle. It turns out
       that it’s turtles all the way down. Miki Rezentes, today’s guest, believes that
@@ -10262,7 +10609,7 @@
     duration: '1:17:12'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/a/a233d61f-e572-4479-a477-18b0d08fb053/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>With ElixirConf 2020 just around the corner, today’s episode
       is a sneak peek where we talk with six of this year’s speakers. Each speaker
       gives listeners an elevator pitch of their talk while throwing in extra details
@@ -10642,7 +10989,7 @@
     duration: '58:51'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/e/e18fef05-5ebe-42a1-9317-b193dfa84cd2/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Domain-driven design and extreme programming can help bridge
       the gap between development and business, and today we invite Mark Windholtz
       from Agile DNA to talk about how! Mark starts out by telling us about his early
@@ -10882,7 +11229,7 @@
     duration: '42:41'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/6/6cf32d50-909b-4839-a690-0fdc8ec48a2f/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Welcome to the second part of our special Elixir Wizards
       Dojo. A mashup made in partnership with ElixirConf Japan. In today’s episode,
       we talk to Nerves core team members Todd Resudek and Connor Rigby about all
@@ -11151,7 +11498,7 @@
     duration: '54:17'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/9/96d50b65-bc90-434e-ae8b-96b7c9f3990d/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Welcome to the first part of our extra special Elixir Wizards
       Dojo. A mashup made in partnership with ElixirConf Japan, in today’s episode,
       we pose questions asked by the Japanese Nerves community to Nerves core team
@@ -11384,7 +11731,7 @@
     duration: '41:43'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/f/f66990d4-1466-41eb-aa79-c89d644f8d94/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>In today’s episode, we chat about system architecture,
       Ruby, Elixir, and everything in between with Greg Mefford, the senior back-end
       engineer for the Bleacher Report. We open the conversation by asking Greg about
@@ -11620,7 +11967,7 @@
     duration: '49:14'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/1/1b6e0936-69df-48a0-83aa-42c3302bcb0a/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Johanna Larsson is a community-minded software engineer
       whose project, Hex Diff, generates highlighted git diffs, right in your browser.
       In this episode, we talk to Johanna about how Hex Diff can benefit Elixir users,
@@ -11845,7 +12192,7 @@
     duration: '37:32'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/f/f39e6147-f6c0-4c1e-803f-d128bfbec255/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Handling date and time is a challenge in any language,
       but Lau Taarnskov is determined to solve that problem in Elixir. Lau is today’s
       guest on Elixir Wizards, and this episode is all about his contributions to
@@ -12031,7 +12378,7 @@
     duration: '55:09'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/e/e9769249-24cb-455c-9983-011f1c414d3d/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>For part 2 of our Council of Wizards panel discussion,
       we are joined by Chris Bell, Desmond Bowe, Emily Maxie, Dan Lindeman, and Alan
       Voss! Chris and Desmond run the ElixirTalk Podcast and we get in-depth on the
@@ -12218,7 +12565,7 @@
     duration: '39:28'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/2/2e71b35e-54cc-4bfe-be34-6567c5fb448c/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>The Elixir community continues to flourish and evolve in
       these uncertain times and in honor of this we have put together a live show
       with a number of special guests! In part one today, we are joined by Andrea
@@ -12391,7 +12738,7 @@
     duration: '43:42'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/c/c87149f2-e430-4fcb-8e22-e3242c625e1b/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Although it’s taken him four seasons to make an appearance,
       we are so glad to finally welcome Chris McCord, creator of the Phoenix framework,
       onto the show. While this season’s focus is on system and application architecture,
@@ -12575,7 +12922,7 @@
     duration: '55:23'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/c/c4183a48-6039-4dc1-b54b-c43973086490/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Today’s guest is Amos King, Principal CEO at Binary Noggin,
       and host on the Elixir Outlaws and This Agile Life podcasts. This episode is
       centered around a casual conversation about everything from programming, the
@@ -12747,7 +13094,7 @@
     duration: '45:58'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/f/f14188bd-903b-49eb-bc8b-f52429966e63/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Welcome to another episode of Elixir Wizards as we continue
       our journey into system and application architecture! Our featured guest today
       is Sundi Myint and she is here to share her journey with Elixir and her non-traditional
@@ -12963,7 +13310,7 @@
     duration: '1:09:43'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/9/9f7ee6f5-a587-4f63-9fc5-ec4cdca6676f/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Dave Thomas is recognized internationally as an expert
       who develops high-quality software–accurate and highly flexible systems. He
       helped write the now-famous Agile Manifesto, and regularly gives inspiring and
@@ -13156,7 +13503,7 @@
     duration: '38:27'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/e/e711fb4d-502b-4733-b5e2-01ff002b836a/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Joining us on the show for this episode is Ben Marx, author
       of Adopting Elixir and Principal Control Plane Engineer at the recently launched
       SubSpace! We continue our Season 4 journey into system and application architecture
@@ -13291,7 +13638,7 @@
     duration: '14:46'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/a/ac3f0d31-f498-4d6a-ba69-3dbae9d0510f/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>A special episode of Elixir Wizards highlighting Pattern
       Matching with Todd - a short format interview where our friend, Todd Resudek,
       asks different guests the same five questions. This week Todd spoke with Johanna
@@ -13376,7 +13723,7 @@
     duration: '49:26'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/b/b07768d6-b987-496e-87d3-483eedd42fa5/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Real-time applications come with real challenges—persistent
       connections, multi-server deployment, and strict performance requirements are
       just a few. Our guest today is Steve Bussey, a software architect at SalesLoft
@@ -13516,7 +13863,7 @@
     duration: '43:22'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/a/a3a16821-cb7c-4c88-be0e-c2b412ad7bee/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Today’s guest is Mohd Maqbool Alam, a software developer
       and Elixir fan from Delhi. He enjoys learning about programming language theory,
       distributed systems, Cloud Native technologies, and open source. As he is working
@@ -13693,7 +14040,7 @@
     duration: '1:09:36'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/3/34c3c1af-3f50-4e83-be65-e7420d65eada/cover.jpg?v=2
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>As our first trilogy comes to a close, and we embark on
       the next one, we’re doing what all great trilogies do: Upending everything that
       made the initial one great and starting afresh. We have taken on board some
@@ -13935,7 +14282,7 @@
     duration: '53:26'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/d/dbe34c01-2361-41a8-ab85-dab81699cc7e/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Welcome back to part two of our betweenisode! Everybody
       is working remotely now including ourselves, so today we continue the catch
       ups we were having with a number of longstanding buddies and chat about life
@@ -14194,7 +14541,7 @@
     duration: '53:16'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/1/1b54b0cf-efaa-46fa-90b5-e40411069750/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>The world has changed so much since the end of season 3,
       that we thought we’d put together a special Betweenisode to tide you over until
       Season 4 launches. In this episode, we talk to several friends and respected
@@ -14412,7 +14759,7 @@
     duration: '50:45'
     explicit: 'no'
     keywords: elixir,phoenix,erlang
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/3/36812119-eef7-40f5-8aba-3fd7b3bebb09/cover.jpg?v=2
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>In this episode, we take a look into the current contexts
       and home lives many of us find ourselves in today, offering top tips for working
       remotely from home during these challenging times. The lockdowns have caused
@@ -14575,7 +14922,7 @@
     duration: '53:54'
     explicit: 'no'
     keywords: elixir,phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/1/19db794e-cf88-4320-969b-ea0ccbe0949d/cover.jpg?v=2
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Welcome to another extra special episode of Elixir Wizards!
       We have guest hosts today, Meryl Dakin of Frame.io and Sophie DeBenedetto of
       Github, and they welcome Steven Nunez, Staff Engineer at the Flatiron School,
@@ -14733,7 +15080,7 @@
     duration: '51:01'
     explicit: 'no'
     keywords: elixir, phoenix, erlang
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/7/75204e87-33b5-4a39-833c-d2a7f5ae1931/cover.jpg?v=2
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Saša Jurić is a household name in the Elixir and Erlang
       space and we are so glad to finally welcome him on to the show today! Author
       of Elixir in Action, Saša is here to discuss training and his thoughts on getting
@@ -14869,7 +15216,7 @@
     duration: '46:44'
     explicit: 'no'
     keywords: elixir, phoenix, lonestar elixir
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg?v=3
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Elixir Outlaws invited us to join them for a special crossover
       episode, recorded live at Lonestar Elixir 2020. Join us for a conversation around
       fun and learning in development, highlights from day one of the conference,
@@ -14966,7 +15313,7 @@
     duration: '48:34'
     explicit: 'no'
     keywords: elixir, ruby, benchee, pandas, erlang
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/6/65360c15-6a60-4c48-be76-94f642cb6869/cover.jpg?v=2
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Our guest today, Devon Estes, approached us about the possible
       opportunity for Elixir to optimize and build out the pandas data analysis and
       manipulation tool, sharing why he thinks it would be a valuable addition to
@@ -15140,7 +15487,7 @@
     duration: '53:38'
     explicit: 'no'
     keywords: lonestar elixir, elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/4/49808f09-dc08-407e-9d3b-9db8f0bbff97/cover.jpg?v=2
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Welcome back to the show for this special edition Lunchisode,
       coming to you live from the Lonestar Elixir 2020 Conference! We have a revolving
       door of speakers at this informal roundtable and a few friends and associates
@@ -15313,7 +15660,7 @@
     duration: '1:10:46'
     explicit: 'no'
     keywords: elixir, phoenix, lonestar
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/1/10fa47c2-0223-46ac-a69d-465fd1393edb/cover.jpg?v=2
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>This week we&#39;re delighted to share a special format
       bonus episode! </p>\n\n<p>We are joined by guest co-host Todd Resudek as well
       as a number of guests who each share a little bit about what they&#39;re working
@@ -15507,7 +15854,7 @@
     duration: '26:11'
     explicit: 'no'
     keywords: DockYard, elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/1/1cd7d8f6-8965-4bd2-b159-1580e133bb6f/cover.jpg?v=2
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Today on the show, we’re joined by Mike Binns and Alex
       Garibay of DockYard. In this episode, Mike and Alex share their journeys of
       how they came to work at DockYard and give us a view into DockYard’s hiring
@@ -15663,7 +16010,7 @@
     duration: '34:34'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/3/37389f65-249a-4e59-bdac-c71a646d2b23/cover.jpg?v=2
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Today on Elixir Wizards we are delighted to be joined by
       Sean Lewis, a senior backend architect at Divvy. One of the many impressive
       facts about Sean is that he is entirely self-taught, from dabbling in Python
@@ -15828,7 +16175,7 @@
     duration: '51:59'
     explicit: 'no'
     keywords: elixir, lumen, rust
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/5/5c493edc-c294-4fdd-b9f9-86a091800d96/cover.jpg?v=2
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>In line with our current working-with-Elixir theme, today
       we’re talking about performance with Paul Schoenfelder and Hans Elias Josephsen
       from DockYard. The two have been working on Lumen, and in this episode, they
@@ -15975,7 +16322,7 @@
     duration: '45:12'
     explicit: 'no'
     keywords: elixir, 2U,Frame.io,github
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/3/37d41249-7185-40c3-a4c3-3d761103ed16/cover.jpg?v=2
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Today on the show we are joined by Sophie DeBenedetto from
       GitHub and Meryl Dakin from Frame.io to talk about the processes involved in
       training others and building Elixir projects. They share about studying and
@@ -16143,7 +16490,7 @@
     duration: '39:26'
     explicit: 'no'
     keywords: elixir, phoenix, fission
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/5/590ef7b4-3a91-4c74-9325-2568d7adecdb/cover.jpg?v=2
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>In today’s episode we have one of our favorite recurring
       guests, Brooklyn Zelenka, joining us once again! Brooklyn has been on the show
       in both the first and second seasons to speak about Elixir and functional programming.
@@ -16293,7 +16640,7 @@
     duration: '38:04'
     explicit: 'no'
     keywords: elixir, phoenix, groxio, lonestar elixir
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/f/f54652e5-c7c3-4165-9c4b-0ddd2ca2d14b/cover.jpg?v=2
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Groxio is a great platform that allows programmers to learn
       new languages easily and broaden their horizons. Our guests today are the team
       behind Groxio, Bruce and Maggie Tate! In our discussion, we cover the basics
@@ -16427,7 +16774,7 @@
     duration: '22:39'
     explicit: 'no'
     keywords: ''
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/e/ea443f10-25a6-4570-9fe8-20e7f6624671/cover.jpg?v=2
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>On today&#39;s show, we are joined by Dan Ivovich from
       our team here at SmartLogic! Dan is the Director of Development Operations and
       has already been a guest and cohost a few times on the show. Today we are talking
@@ -16589,7 +16936,7 @@
     duration: '37:10'
     explicit: 'no'
     keywords: hex, elixir, mint
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/e/ef0d105d-13f1-4803-8837-341f56782510/cover.jpg?v=2
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>We are happy to be joined in this episode by Eric Meadows
       Jönsson, creator of the hexpm package manager, and an amazing resource who works
       tirelessly to build the Elixir community. Eric presently works at Brex and was
@@ -16812,7 +17159,7 @@
     duration: '35:26'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/b/b26cdd89-0d68-4466-9714-44c278932651/cover.jpg?v=2
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Our guest on the show today is blogger, software cowboy,
       and podcast host Chris Keathley. Chris is a senior engineer at Bleacher Report,
       co-host of Elixir Outlaws, and writer of an assemblage of open-source software.
@@ -17001,7 +17348,7 @@
     duration: '38:47'
     explicit: 'no'
     keywords: elixir, nerves, erlang
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/2/2be72d78-cfcc-46e2-a0a5-753fc8a0c280/cover.jpg?v=2
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>On today’s show, we welcome Justin Schneck and Frank Hunleth,
       luminaries from the Nerves team! We take a dive into the world of Nerves with
       them, covering themes of performance, problem-solving, transitioning to hardware,
@@ -17144,7 +17491,7 @@
     duration: '27:21'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/f/f816f14f-9675-4d38-a622-24dd6eb29cd1/cover.jpg?v=2
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Our theme this season is working with Elixir, and joining
       in the conversation today is Brad Traylor from Podium. Brad shares his expertise
       in hiring and training for Podium, a position he is passionate about since it
@@ -17284,7 +17631,7 @@
     duration: '43:40'
     explicit: 'no'
     keywords: elixir
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/1/13faacd6-6639-4fe7-a552-5f58e3dc2f3d/cover.jpg?v=3
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Today on Elixir Wizards we are joined by none other than
       José Valim, the inventor of Elixir! Coming from the Ruby on Rails world, José
       found his way to functional programming and we hear all about the evolution
@@ -17411,7 +17758,7 @@
     duration: '25:40'
     explicit: 'no'
     keywords: elixirconf, functional programming, elixir
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/7/7f21096c-8f00-4f06-9b4a-a0a8b554e28b/cover.jpg?v=2
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Welcome to Elixir Wizards, today we are joined by Dr. Jim
       Freeze to talk about his passion for and history in Elixir and functional programming.
       Dr. Freeze is one of the organizers of one of our favorite things in the world,
@@ -17531,7 +17878,7 @@
     duration: '11:53'
     explicit: 'no'
     keywords: ''
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg?v=3
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Welcome to the last episode of Season 2 of the podcast!
       We are taking this opportunity to recap what we covered in the season and talk
       about what we liked and what we didn&#39;t like so much. We do not have a guest
@@ -17656,7 +18003,7 @@
     duration: '32:31'
     explicit: 'no'
     keywords: elixir, rustler, rust, elm, simplebet
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/1/1f938053-676b-4137-ad82-f104ebda9488/cover.jpg?v=3
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Our guest today on the show is Dave Lucia, who is currently
       the Vice President of Engineering at SimpleBet. He is here as part of Elixir
       Internals series, to talk to us and all our listeners about Rustler and the
@@ -17781,7 +18128,7 @@
     duration: '29:26'
     explicit: 'no'
     keywords: exventure
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/0/0a947a18-82f2-4b2e-8c0c-69696c5980d9/cover.jpg?v=3
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>This season on Smart Software Season 2, we are focused
       on the inner workings of Elixir and the inner workings of popular Elixir libraries,
       or Elixir internals. Today, I have the pleasure of interviewing my colleague,
@@ -17878,7 +18225,7 @@
     duration: '30:42'
     explicit: 'no'
     keywords: ''
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/7/7b360fac-dde4-44a4-b637-762e19a0274b/cover.jpg?v=3
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Welcome to another episode of the podcast everybody! As
       we continue our journey into Elixir internals in Season 2, we welcome Sophie
       DeBenedetto to tell us about the two libraries she and the Flatiron School created!
@@ -18016,7 +18363,7 @@
     duration: '28:57'
     explicit: 'no'
     keywords: ''
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/e/ec6a1593-38d7-48b0-8494-9dd83f8f6cff/cover.jpg?v=3
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Today on the show we welcome Shanti Chellaram to talk about
       a couple of Erlang libraries she has created! We hear from her about Pri-Queue
       and raft_erl, and her motivation behind making them and some of the things we
@@ -18166,7 +18513,7 @@
     duration: '27:31'
     explicit: 'no'
     keywords: elixir, erlang, ecto, jason
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/d/d20c39c5-2b6c-44a9-96ff-0dff754dd08f/cover.jpg?v=3
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Today on the show we are joined by Michal Muskala, who
       is currently a freelance software engineer and he is here to talk to us about
       his work on the Ecto and jason libraries. With Ecto we continue our journey
@@ -18307,7 +18654,7 @@
     duration: '34:00'
     explicit: 'no'
     keywords: ''
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/2/2ebfdc2e-d967-4324-bcbe-de67bccb57e6/cover.jpg?v=3
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Today on the show we get stuck into the inner workings
       of Hex 1.0 and are happy to be joined by returning guest, Todd Resudek. As you
       might already know, Todd is the Senior Software Engineer at Weedmaps, a regular
@@ -18427,7 +18774,7 @@
     duration: '26:46'
     explicit: 'no'
     keywords: ''
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/3/37e3efb0-85b7-4dd9-bbf9-a997b01c6437/cover.jpg?v=3
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>In this episode of the podcast we are joined by Chris Keathley
       to continue our exploration of Elixir internals as he tells us about two very
       popular libraries that he developed, Wallaby and Raft. We start off with some
@@ -18556,7 +18903,7 @@
     duration: '29:36'
     explicit: 'no'
     keywords: elixir, credo
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/9/9532d3dd-1d07-4ac9-b4c8-3f1580deff11/cover.jpg?v=3
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Welcome back to the SmartLogic Podcast where we talk about
       the latest developments and best practices in the web and mobile software industry.
       In continuing with our theme of Elixir Internals, we’re having a conversation
@@ -18694,7 +19041,7 @@
     duration: '27:31'
     explicit: 'no'
     keywords: elixir, wework, flatiron school, token alchemist
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/3/3050865c-0418-42d6-ade9-9605af11fee6/cover.jpg?v=3
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Today on the show we continue our series on the inner workings
       of several different Elixir libraries and are happy to be joined by Meryl Dakin,
       Software Engineer at the Flatiron School and author of Token Alchemist. In this
@@ -18817,7 +19164,7 @@
     duration: '29:45'
     explicit: 'no'
     keywords: elixir, distillery
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/b/bd39f088-71c3-4425-b78e-8fc4a5324a1c/cover.jpg?v=3
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Welcome back to show everyone and today in our exploration
       of Elixir libraries we are talking to Paul Schoenfelder! He is here to unpack
       Distillery, his own creation from the world of Elixir and tell us about how
@@ -18931,7 +19278,7 @@
     duration: '23:56'
     explicit: 'no'
     keywords: elixir, elixirscript, the big elixir
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/e/ed1a46a8-a3ac-4808-b1e5-91e950b2791a/cover.jpg?v=3
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Today on the show we continue our series on the inner workings
       and various libraries of Elixir and are very happy to welcome Bryan Joseph of
       Revelry to talk about his very own ElixirScript. ElixirScript is essentially
@@ -19060,7 +19407,7 @@
     duration: '30:15'
     explicit: 'no'
     keywords: elixir, witchcraft, dialyzer
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/4/490b7cc3-44d7-4917-9688-2450d18de62a/cover.jpg?v=3
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Hey everybody and welcome back to Season 2 of the podcast!
       This season we will be talking about Elixir internals, libraries and the inner
       workings of the language. In our first episode we are very happy to be joined
@@ -19168,7 +19515,7 @@
     duration: '20:03'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg?v=3
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>With this season over, we bring Dan Ivovich back to talk
       about what we learned.</p>\n\n<p>Dan Ivovich - Director of Development Operations
       @ SmartLogic</p>\n\n<p>00:43 - Why are you using Elixir in production?<br>\n01:20
@@ -19227,7 +19574,7 @@
     duration: '43:54'
     explicit: 'no'
     keywords: elixir, phoenix, production
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/7/7bd99e2e-cba0-4c94-904a-5486ce48c517/cover.jpg?v=2
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>We talk with Jeffrey Matthias from Community about their
       current and past Elixir projects and how they are deployed.</p>\n\n<p>Jeffrey
       Matthias - <a href=\"https://www.community.com/\" rel=\"nofollow\">Community</a></p>\n\n<p>Find
@@ -19400,7 +19747,7 @@
     duration: '17:25'
     explicit: 'no'
     keywords: elixir, phoenix, production
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/c/c300841a-d5b9-4957-950f-ce0f6bc3af68/cover.jpg?v=2
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>We talk with Jay Ashe from Cava about their current and
       past Elixir projects and how they are deployed.</p>\n\n<p>Jay Ashe - <a href=\"https://cava.com/\"
       rel=\"nofollow\">Cava</a></p>\n\n<p>Find Jay elsewhere online:<br>\n<a href=\"https://twitter.com/jgashe\"
@@ -19647,7 +19994,7 @@
     duration: '28:47'
     explicit: 'no'
     keywords: elixir, nerves, production
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/a/ad538aa5-ad67-418b-b07f-0be38fff2f6b/cover.jpg?v=2
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>We talk with Frank Hunleth from the Nerves core team about
       their current and past Elixir projects and how they are deployed.</p>\n\n<p>Frank
       Hunleth - <a href=\"https://nerves-project.org/\" rel=\"nofollow\">Nerves</a></p>\n\n<p>Find
@@ -19729,7 +20076,7 @@
     duration: '36:34'
     explicit: 'no'
     keywords: elixir, phoenix, production
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/4/4a5a2fb4-c1a0-437a-9001-9b981312ecab/cover.jpg?v=2
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>We talk with Mark Ericksen from Elixir Mix about their
       current and past Elixir projects and how they are deployed.</p>\n\n<p>Mark Ericksen
       - <a href=\"https://devchat.tv/elixir-mix/\" rel=\"nofollow\">Elixir Mix</a></p>\n\n<p>Find
@@ -19842,7 +20189,7 @@
     duration: '27:46'
     explicit: 'no'
     keywords: elixir, phoenix, spade co
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/0/0cef68be-a246-4ba6-bdc7-a6835c05fe72/cover.jpg?v=2
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>We talk with Brooklyn Zelenka from SPADE Co. about their
       current and past Elixir projects and how they are deployed.</p>\n\n<p>Brooklyn
       Zelenka - <a href=\"https://spade.builders/\" rel=\"nofollow\">SPADE Co.</a></p>\n\n<p>Find
@@ -19954,7 +20301,7 @@
     duration: '26:01'
     explicit: 'no'
     keywords: elixir, phoenix, weedmaps
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/d/d949b81e-39c5-4474-8605-89062b8dc543/cover.jpg?v=2
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>We talk with Todd Resudek from Weedmaps about their current
       Elixir projects and how they are deployed.</p>\n\n<p>Todd Resudek - <a href=\"https://weedmaps.com/\"
       rel=\"nofollow\">Weedmaps</a></p>\n\n<p>Find Todd elsewhere online:<br>\n<a
@@ -20041,7 +20388,7 @@
     duration: '49:26'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/4/4646981d-f12c-479e-a5cc-7629570962ed/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>We sat down with numerous developers, including José Valim
       and Chris McCord, during the Saturday lunch at <a href=\"https://lonestarelixir.com/2019/\"
       rel=\"nofollow\">Lonestar ElixirConf 2019</a>. Hear what they had to say about
@@ -20137,7 +20484,7 @@
     duration: '32:34'
     explicit: 'no'
     keywords: elixir, phoenix, clustertruck
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/9/9b17b0c6-6e66-4e77-ae1f-9b3e2db6a35b/cover.jpg?v=3
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>We talk with Ryan Billingsley from ClusterTruck about their
       current Elixir projects and how they are deployed.</p>\n\n<p>Ryan Billingsley
       - <a href=\"https://www.clustertruck.com/\" rel=\"nofollow\">ClusterTruck</a></p>\n\n<p>Find
@@ -20257,7 +20604,7 @@
     duration: '28:28'
     explicit: 'no'
     keywords: elixir, phoenix, smartlogic
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/f/f71af757-ce4c-44a0-8e78-5766711fd7d4/cover.jpg?v=2
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>We talk with developers from the team here at SmartLogic
       about our current practices on deploying Elixir and Phoenix in production.</p>\n\n<p>Dan
       Ivovich - Director of Development Operations @ SmartLogic</p>\n\n<p>Learn more

--- a/_data/elixir_wizards_feed.yml
+++ b/_data/elixir_wizards_feed.yml
@@ -1,12 +1,12 @@
 ---
 title: Elixir Wizards
-pubDate: Thu, 22 Sep 2022 11:07:35 -0000
+pubDate: Thu, 13 Oct 2022 10:45:05 -0000
 link: https://smartlogic.io/podcast/elixir-wizards
 description: "Elixir Wizards is an interview-format podcast, focused on engineers
   who use the Elixir programming language. Initially launched in early 2019, each
   season focuses on a specific topic or topics, with each interview focusing on the
-  guest's experience and opinions on the topic.\nElixir Wizards is hosted by Alex
-  Housand, Sundi Myint, and Eric Oestrich of SmartLogic, a dev shop that’s been building
+  guest's experience and opinions on the topic.\nElixir Wizards is hosted by Sundi
+  Myint, Owen Bickford, and Bilal Hankins of SmartLogic, a dev shop that’s been building
   custom software since 2005 and running Elixir applications in production since 2015.\nLearn
   more about how SmartLogic uses Phoenix and Elixir. (https://smartlogic.io/phoenix-and-elixir?utm_source=podcast)
   \n"
@@ -34,7 +34,7 @@ items:
     duration: '1:40'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg?v=3
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Welcome back to Season 3! Our theme this time around is
       Working with Elixir. Listen for more on our theme, upcoming guests, and our
       new name.</p>\n      "
@@ -66,7 +66,7 @@ items:
     duration: '1:26'
     explicit: 'no'
     keywords: ''
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg?v=3
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>We’re excited to announce our season two topic, Elixir
       Internals. In this season we talk with developers behind some of the most popular
       Elixir libraries, including Witchcraft, ElixirScript, Distillery, Ecto, and
@@ -103,7 +103,7 @@ items:
     duration: '1:24'
     explicit: 'no'
     keywords: elixir, phoenix, production
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg?v=3
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Welcome to the first season of Smart Software with SmartLogic.
       We&#39;ll be interviewing several companies about how they use Elixir in Production
       this season. In this preview episode, we introduce ourselves and some of the
@@ -116,13 +116,327 @@ items:
     some of the topics we’ll be covering.</p>\n\n<p>Learn more about how SmartLogic
     uses <a href=\"https://smr.tl/2Hyslu8\" rel=\"nofollow\">Phoenix and Elixir.</a></p>\n
     \     "
+- title: 'Tyler Young on Geo Mapping at Felt '
+  slug: s9e3-tyleryoung-felt
+  link: https://smartlogic.io/podcast/elixir-wizards/s9e3-tyleryoung-felt
+  guid: 457bc018-a109-4457-b7bd-693ebd2ef38e
+  pubDate: Thu, 13 Oct 2022 06:00:00 -0400
+  pubDateFriendly: October 13, 2022
+  description: "Today on Elixir Wizards we are joined by Tyler Young to explore the
+    particulars of Geo Mapping, the process of turning data into maps. Tyler is a
+    Senior Software Developer at Felt, the world’s first collaborative mapping tool
+    built for anyone to make a beautiful map in minutes. Tune in today to learn more
+    about Geo Mapping from today’s special guest, Tyler Young!\nKey Points From This
+    Episode:\nA brief breakdown of today’s topic and introduction to our special guest,
+    Tyler Young\nWe discover Tyler’s background and how he started working in Elixir,
+    as well as how he got into the map business because of his love for Elixir \nWe
+    learn about GIS and its history as a system/standard/protocol, and how someone
+    can study GIS \nFind out how mapping is helpful in more ways than just for directions,
+    including climate changes, vacation planning, and more\nTyler breaks down the
+    common technologies and toolkits for programming with maps \nThe specific tools
+    that Felt is using to ingest map data and build the interactive maps \nWhat common
+    problems arise when developing with maps\nTyler teaches the Elixir Wizards about
+    his tried and true way of decision making with “The McDonald’s option” \n_\n**Links
+    Mentioned in Today’s Episode:\nTyler Young on Twitter — https://twitter.com/TylerAYoung\nTyler
+    Young on GitHub — https://github.com/s3cur3\nTyler Young on LinkedIn — https://www.linkedin.com/in/tyler-young-dev/\nFelt
+    — https://felt.com/about\nSmartLogic — https://smartlogic.io/\nSmartLogic Twitter
+    — https://twitter.com/smartlogic\n"
+  author: SmartLogic LLC
+  embedUrl: https://fireside.fm/player/v2/IAs5ixts+373p2LD-
+  enclosure:
+    url: https://aphid.fireside.fm/d/1437767933/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/457bc018-a109-4457-b7bd-693ebd2ef38e.mp3
+    length: '31075529'
+    type: audio/mpeg
+  itunes:
+    episodeType: full
+    season: '9'
+    author: SmartLogic LLC
+    subtitle: Today on Elixir Wizards we are joined by Tyler Young to explore the
+      particulars of Geo Mapping, the process of turning data into maps. Tyler is
+      a Senior Software Developer at Felt, the world’s first collaborative mapping
+      tool built for anyone to make a beautiful map in minutes. Tune in today to learn
+      more about Geo Mapping from today’s special guest, Tyler Young!
+    duration: '36:59'
+    explicit: 'no'
+    keywords: elixir, geo mapping, tech, felt
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
+    summary: "\n        <p>Today on Elixir Wizards we are joined by Tyler Young to
+      explore the particulars of Geo Mapping, the process of turning data into maps.
+      Tyler is a Senior Software Developer at Felt, the world’s first collaborative
+      mapping tool built for anyone to make a beautiful map in minutes. Tune in today
+      to learn more about Geo Mapping from today’s special guest, Tyler Young!</p>\n\n<p>Key
+      Points From This Episode:</p>\n\n<ul>\n<li>A brief breakdown of today’s topic
+      and introduction to our special guest, Tyler Young</li>\n<li>We discover Tyler’s
+      background and how he started working in Elixir, as well as how he got into
+      the map business because of his love for Elixir </li>\n<li>We learn about GIS
+      and its history as a system/standard/protocol, and how someone can study GIS
+      </li>\n<li>Find out how mapping is helpful in more ways than just for directions,
+      including climate changes, vacation planning, and more</li>\n<li>Tyler breaks
+      down the common technologies and toolkits for programming with maps </li>\n<li>The
+      specific tools that Felt is using to ingest map data and build the interactive
+      maps </li>\n<li>What common problems arise when developing with maps</li>\n<li><p>Tyler
+      teaches the Elixir Wizards about his tried and true way of decision making with
+      “The McDonald’s option” <br>\n_<br>\n**Links Mentioned in Today’s Episode:</p></li>\n<li><p>Tyler
+      Young on Twitter — <a href=\"https://twitter.com/TylerAYoung\" rel=\"nofollow\">https://twitter.com/TylerAYoung</a></p></li>\n<li><p>Tyler
+      Young on GitHub — <a href=\"https://github.com/s3cur3\" rel=\"nofollow\">https://github.com/s3cur3</a></p></li>\n<li><p>Tyler
+      Young on LinkedIn — <a href=\"https://www.linkedin.com/in/tyler-young-dev/\"
+      rel=\"nofollow\">https://www.linkedin.com/in/tyler-young-dev/</a></p></li>\n<li><p>Felt
+      — <a href=\"https://felt.com/about\" rel=\"nofollow\">https://felt.com/about</a></p></li>\n<li><p>SmartLogic
+      — <a href=\"https://smartlogic.io/\" rel=\"nofollow\">https://smartlogic.io/</a></p></li>\n<li><p>SmartLogic
+      Twitter — <a href=\"https://twitter.com/smartlogic\" rel=\"nofollow\">https://twitter.com/smartlogic</a></p></li>\n</ul>\n
+      \     "
+  contentEncoded: "\n        <p>Today on Elixir Wizards we are joined by Tyler Young
+    to explore the particulars of Geo Mapping, the process of turning data into maps.
+    Tyler is a Senior Software Developer at Felt, the world’s first collaborative
+    mapping tool built for anyone to make a beautiful map in minutes. Tune in today
+    to learn more about Geo Mapping from today’s special guest, Tyler Young!</p>\n\n<p>Key
+    Points From This Episode:</p>\n\n<ul>\n<li>A brief breakdown of today’s topic
+    and introduction to our special guest, Tyler Young</li>\n<li>We discover Tyler’s
+    background and how he started working in Elixir, as well as how he got into the
+    map business because of his love for Elixir </li>\n<li>We learn about GIS and
+    its history as a system/standard/protocol, and how someone can study GIS </li>\n<li>Find
+    out how mapping is helpful in more ways than just for directions, including climate
+    changes, vacation planning, and more</li>\n<li>Tyler breaks down the common technologies
+    and toolkits for programming with maps </li>\n<li>The specific tools that Felt
+    is using to ingest map data and build the interactive maps </li>\n<li>What common
+    problems arise when developing with maps</li>\n<li><p>Tyler teaches the Elixir
+    Wizards about his tried and true way of decision making with “The McDonald’s option”
+    <br>\n_<br>\n**Links Mentioned in Today’s Episode:</p></li>\n<li><p>Tyler Young
+    on Twitter — <a href=\"https://twitter.com/TylerAYoung\" rel=\"nofollow\">https://twitter.com/TylerAYoung</a></p></li>\n<li><p>Tyler
+    Young on GitHub — <a href=\"https://github.com/s3cur3\" rel=\"nofollow\">https://github.com/s3cur3</a></p></li>\n<li><p>Tyler
+    Young on LinkedIn — <a href=\"https://www.linkedin.com/in/tyler-young-dev/\" rel=\"nofollow\">https://www.linkedin.com/in/tyler-young-dev/</a></p></li>\n<li><p>Felt
+    — <a href=\"https://felt.com/about\" rel=\"nofollow\">https://felt.com/about</a></p></li>\n<li><p>SmartLogic
+    — <a href=\"https://smartlogic.io/\" rel=\"nofollow\">https://smartlogic.io/</a></p></li>\n<li><p>SmartLogic
+    Twitter — <a href=\"https://twitter.com/smartlogic\" rel=\"nofollow\">https://twitter.com/smartlogic</a></p></li>\n</ul>\n
+    \     "
+- title: Kate Rezentes on GenServers at Simplebet
+  slug: s9e2-kate-rezentes-simplebet
+  link: https://smartlogic.io/podcast/elixir-wizards/s9e2-kate-rezentes-simplebet
+  guid: 7bcfea5b-42f1-4dc9-9384-3b37f432a636
+  pubDate: Thu, 06 Oct 2022 06:00:00 -0400
+  pubDateFriendly: October  6, 2022
+  description: "Season 9 is in full swing and we are so excited to welcome Kate Rezentes
+    today to dive into the particulars of GenServers. Kate is a Junior Software Developer
+    at Simplebet, a B2B product development company using machine learning and real-time
+    technology to make every moment of every sporting event a betting opportunity.
+    Tune in today to learn more from today’s special guest, Kate Rezentes!\nKey Points
+    From This Episode:\n A brief breakdown of today’s topic and introduction to our
+    special guest, Kate Rezentes \n We learn about Kate’s background and her long
+    history with programming\nWe discuss how many conferences she’s attended and why
+    ElixirConf has been her favorite (thus far)\n Find out how Kate landed a job while
+    attending ElixirConf\n How GenServers as a subject came to be\nWe get an inside
+    look at Kate’s working experience at Simplebet and her experience as a Junior
+    Engineer in the industry so far \nWhat cases in particular cause the need for
+    a GenServer\nWe discuss where GenServers would be appropriate to use and why\nThe
+    ins and outs of ‘handle calls’ and ‘callbacks’\nThe process of testing a GenServer
+    and data storage_\n**Links Mentioned in Today’s Episode:*\nKate Rezentes on Twitter
+    — https://twitter.com/rezkate\nKate Rezentes on GitHub — https://github.com/KateRezentes\nKate
+    Rezentes on LinkedIn — https://www.linkedin.com/in/kfrezent/\nSimplebet — https://simplebet.io/\nSmartLogic
+    — https://smartlogic.io/\nSmartLogic Twitter — https://twitter.com/smartlogic\n"
+  author: SmartLogic LLC
+  embedUrl: https://fireside.fm/player/v2/IAs5ixts+TZBECxVc
+  enclosure:
+    url: https://aphid.fireside.fm/d/1437767933/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/7bcfea5b-42f1-4dc9-9384-3b37f432a636.mp3
+    length: '46206464'
+    type: audio/mpeg
+  itunes:
+    episodeType: full
+    season: '9'
+    author: SmartLogic LLC
+    subtitle: Season 9 is in full swing and we are so excited to welcome Kate Rezentes
+      today to dive into the particulars of GenServers. Kate is a Junior Software
+      Developer at Simplebet, a B2B product development company using machine learning
+      and real-time technology to make every moment of every sporting event a betting
+      opportunity. Tune in today to learn more from today’s special guest, Kate Rezentes!
+    duration: '48:07'
+    explicit: 'no'
+    keywords: simplebet, genservers, elixir, smartlogic
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
+    summary: "\n        <p>Season 9 is in full swing and we are so excited to welcome
+      Kate Rezentes today to dive into the particulars of GenServers. Kate is a Junior
+      Software Developer at Simplebet, a B2B product development company using machine
+      learning and real-time technology to make every moment of every sporting event
+      a betting opportunity. Tune in today to learn more from today’s special guest,
+      Kate Rezentes!</p>\n\n<p>Key Points From This Episode:</p>\n\n<ul>\n<li> A brief
+      breakdown of today’s topic and introduction to our special guest, Kate Rezentes
+      </li>\n<li> We learn about Kate’s background and her long history with programming</li>\n<li>We
+      discuss how many conferences she’s attended and why ElixirConf has been her
+      favorite (thus far)</li>\n<li> Find out how Kate landed a job while attending
+      ElixirConf</li>\n<li> How GenServers as a subject came to be</li>\n<li>We get
+      an inside look at Kate’s working experience at Simplebet and her experience
+      as a Junior Engineer in the industry so far </li>\n<li>What cases in particular
+      cause the need for a GenServer</li>\n<li>We discuss where GenServers would be
+      appropriate to use and why</li>\n<li>The ins and outs of ‘handle calls’ and
+      ‘callbacks’</li>\n<li>The process of testing a GenServer and data storage_</li>\n</ul>\n\n<p><em>**Links
+      Mentioned in Today’s Episode:</em>*</p>\n\n<ul>\n<li>Kate Rezentes on Twitter
+      — <a href=\"https://twitter.com/rezkate\" rel=\"nofollow\">https://twitter.com/rezkate</a></li>\n<li>Kate
+      Rezentes on GitHub — <a href=\"https://github.com/KateRezentes\" rel=\"nofollow\">https://github.com/KateRezentes</a></li>\n<li>Kate
+      Rezentes on LinkedIn — <a href=\"https://www.linkedin.com/in/kfrezent/\" rel=\"nofollow\">https://www.linkedin.com/in/kfrezent/</a></li>\n<li>Simplebet
+      — <a href=\"https://simplebet.io/\" rel=\"nofollow\">https://simplebet.io/</a></li>\n<li>SmartLogic
+      — <a href=\"https://smartlogic.io/\" rel=\"nofollow\">https://smartlogic.io/</a></li>\n<li>SmartLogic
+      Twitter — <a href=\"https://twitter.com/smartlogic\" rel=\"nofollow\">https://twitter.com/smartlogic</a></li>\n</ul>\n
+      \     "
+  contentEncoded: "\n        <p>Season 9 is in full swing and we are so excited to
+    welcome Kate Rezentes today to dive into the particulars of GenServers. Kate is
+    a Junior Software Developer at Simplebet, a B2B product development company using
+    machine learning and real-time technology to make every moment of every sporting
+    event a betting opportunity. Tune in today to learn more from today’s special
+    guest, Kate Rezentes!</p>\n\n<p>Key Points From This Episode:</p>\n\n<ul>\n<li>
+    A brief breakdown of today’s topic and introduction to our special guest, Kate
+    Rezentes </li>\n<li> We learn about Kate’s background and her long history with
+    programming</li>\n<li>We discuss how many conferences she’s attended and why ElixirConf
+    has been her favorite (thus far)</li>\n<li> Find out how Kate landed a job while
+    attending ElixirConf</li>\n<li> How GenServers as a subject came to be</li>\n<li>We
+    get an inside look at Kate’s working experience at Simplebet and her experience
+    as a Junior Engineer in the industry so far </li>\n<li>What cases in particular
+    cause the need for a GenServer</li>\n<li>We discuss where GenServers would be
+    appropriate to use and why</li>\n<li>The ins and outs of ‘handle calls’ and ‘callbacks’</li>\n<li>The
+    process of testing a GenServer and data storage_</li>\n</ul>\n\n<p><em>**Links
+    Mentioned in Today’s Episode:</em>*</p>\n\n<ul>\n<li>Kate Rezentes on Twitter
+    — <a href=\"https://twitter.com/rezkate\" rel=\"nofollow\">https://twitter.com/rezkate</a></li>\n<li>Kate
+    Rezentes on GitHub — <a href=\"https://github.com/KateRezentes\" rel=\"nofollow\">https://github.com/KateRezentes</a></li>\n<li>Kate
+    Rezentes on LinkedIn — <a href=\"https://www.linkedin.com/in/kfrezent/\" rel=\"nofollow\">https://www.linkedin.com/in/kfrezent/</a></li>\n<li>Simplebet
+    — <a href=\"https://simplebet.io/\" rel=\"nofollow\">https://simplebet.io/</a></li>\n<li>SmartLogic
+    — <a href=\"https://smartlogic.io/\" rel=\"nofollow\">https://smartlogic.io/</a></li>\n<li>SmartLogic
+    Twitter — <a href=\"https://twitter.com/smartlogic\" rel=\"nofollow\">https://twitter.com/smartlogic</a></li>\n</ul>\n
+    \     "
+- title: Dave Lucia on Observability at Bitfo
+  slug: s9e1-dave-lucia-bitfo
+  link: https://smartlogic.io/podcast/elixir-wizards/s9e1-dave-lucia-bitfo
+  guid: ccdb0e5d-3009-44db-9573-d5a5a12696eb
+  pubDate: Thu, 29 Sep 2022 03:00:00 -0400
+  pubDateFriendly: September 29, 2022
+  description: |
+    Welcome to our first episode of Season 9 Elixir Wizards, Parsing the Particulars. A show focused on conversations with software developers from around the world on the Elixir language and other modern web technologies. Today, we are joined by Dave Lucia, Chief Technology Officer at Bitfo, a cryptocurrency media company building educational content for people who are interested in cryptocurrency. Dave is active in the Elixir community and in the past has spoken at Code BEAM SF, ElixirConf, RabbitMQ Summit, and has written several blog posts which can be found at davelucia.com. In today’s episode we find out more about Dave’s professional background and dive into the particulars of observability. Tune in today to learn more from today’s special guest, Dave Lucia!
+    Key Points From This Episode:
+    A brief breakdown of today’s topic and introduction to our special guest, Dave Lucia
+    We find out about Bitfo and what services they offer
+    We discuss Dave’s blog post on observability
+    Find out how Dave wrote the blog post because he saw a gap at his company
+    How Sundi proofread Dave’s blog post and realized her lack of knowledge on observability
+    The most common mistake teams or engineers make when it comes to observability
+    We peel back the layers on what telemetry is
+    What the difference between telemetry and OpenTelemetry is
+    How to choose which tool is right when it comes to better observability
+    *The breakdown of the uses for observability telemetry
+    *When and why would we use OpenTelemtry vs basic observability
+    *What languages Dave started in before he was working in Elixir
+    *How Elixir lends better for observability
+    *Where to start if you want to implement basic observability for someone who has no experience with it
+    *Dave answers the question, “can you go too far with observability?”
+    *We discuss Livebook and what exciting things it will bring for the future
+    *Most importantly, Dave explains why pineapples are important to him
+    **Links Mentioned in Today’s Episode:
+    Dave’s blog post on Observability: https://davelucia.com/blog/observing-elixir-with-lightstep
+    Dave Lucia on Twitter — https://twitter.com/davydog187
+    Dave Lucia on GitHub — https://github.com/davydog187
+    Dave Lucia on LinkedIn — https://www.linkedin.com/in/david-lucia-a395441b/
+    Bitfo — https://www.bitfo.com/
+    SmartLogic — https://smartlogic.io/
+  author: SmartLogic LLC
+  embedUrl: https://fireside.fm/player/v2/IAs5ixts+87YV43bE
+  enclosure:
+    url: https://aphid.fireside.fm/d/1437767933/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/ccdb0e5d-3009-44db-9573-d5a5a12696eb.mp3
+    length: '74289426'
+    type: audio/mpeg
+  itunes:
+    episodeType: full
+    season: '9'
+    author: SmartLogic LLC
+    subtitle: ''
+    duration: '51:35'
+    explicit: 'no'
+    keywords: bitfo, crypto, elixir, observability
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
+    summary: "\n        <p>Welcome to our first episode of Season 9 Elixir Wizards,
+      Parsing the Particulars. A show focused on conversations with software developers
+      from around the world on the Elixir language and other modern web technologies.
+      Today, we are joined by Dave Lucia, Chief Technology Officer at Bitfo, a cryptocurrency
+      media company building educational content for people who are interested in
+      cryptocurrency. Dave is active in the Elixir community and in the past has spoken
+      at Code BEAM SF, ElixirConf, RabbitMQ Summit, and has written several blog posts
+      which can be found at davelucia.com. In today’s episode we find out more about
+      Dave’s professional background and dive into the particulars of observability.
+      Tune in today to learn more from today’s special guest, Dave Lucia!</p>\n\n<p>Key
+      Points From This Episode:</p>\n\n<ul>\n<li>A brief breakdown of today’s topic
+      and introduction to our special guest, Dave Lucia</li>\n<li>We find out about
+      Bitfo and what services they offer</li>\n<li>We discuss Dave’s blog post on
+      observability</li>\n<li>Find out how Dave wrote the blog post because he saw
+      a gap at his company</li>\n<li>How Sundi proofread Dave’s blog post and realized
+      her lack of knowledge on observability</li>\n<li>The most common mistake teams
+      or engineers make when it comes to observability</li>\n<li>We peel back the
+      layers on what telemetry is</li>\n<li>What the difference between telemetry
+      and OpenTelemetry is</li>\n<li>How to choose which tool is right when it comes
+      to better observability\n*The breakdown of the uses for observability telemetry\n*When
+      and why would we use OpenTelemtry vs basic observability\n*What languages Dave
+      started in before he was working in Elixir\n*How Elixir lends better for observability\n*Where
+      to start if you want to implement basic observability for someone who has no
+      experience with it\n*Dave answers the question, “can you go too far with observability?”\n*We
+      discuss Livebook and what exciting things it will bring for the future\n*Most
+      importantly, Dave explains why pineapples are important to him</li>\n</ul>\n\n<p>**Links
+      Mentioned in Today’s Episode:</p>\n\n<ul>\n<li>Dave’s blog post on Observability:
+      <a href=\"https://davelucia.com/blog/observing-elixir-with-lightstep\" rel=\"nofollow\">https://davelucia.com/blog/observing-elixir-with-lightstep</a></li>\n<li>Dave
+      Lucia on Twitter — <a href=\"https://twitter.com/davydog187\" rel=\"nofollow\">https://twitter.com/davydog187</a></li>\n<li>Dave
+      Lucia on GitHub — <a href=\"https://github.com/davydog187\" rel=\"nofollow\">https://github.com/davydog187</a></li>\n<li>Dave
+      Lucia on LinkedIn — <a href=\"https://www.linkedin.com/in/david-lucia-a395441b/\"
+      rel=\"nofollow\">https://www.linkedin.com/in/david-lucia-a395441b/</a></li>\n<li>Bitfo
+      — <a href=\"https://www.bitfo.com/\" rel=\"nofollow\">https://www.bitfo.com/</a></li>\n<li>SmartLogic
+      — <a href=\"https://smartlogic.io/\" rel=\"nofollow\">https://smartlogic.io/</a></li>\n</ul><p>Links:</p><ul><li><a
+      href=\"https://open.spotify.com/episode/3RmFXCjuVIsT1DqzqSZgAv?si=1c5d7a3171164223\"
+      title=\"Spotify\" rel=\"nofollow\">Spotify</a></li></ul>\n      "
+  contentEncoded: "\n        <p>Welcome to our first episode of Season 9 Elixir Wizards,
+    Parsing the Particulars. A show focused on conversations with software developers
+    from around the world on the Elixir language and other modern web technologies.
+    Today, we are joined by Dave Lucia, Chief Technology Officer at Bitfo, a cryptocurrency
+    media company building educational content for people who are interested in cryptocurrency.
+    Dave is active in the Elixir community and in the past has spoken at Code BEAM
+    SF, ElixirConf, RabbitMQ Summit, and has written several blog posts which can
+    be found at davelucia.com. In today’s episode we find out more about Dave’s professional
+    background and dive into the particulars of observability. Tune in today to learn
+    more from today’s special guest, Dave Lucia!</p>\n\n<p>Key Points From This Episode:</p>\n\n<ul>\n<li>A
+    brief breakdown of today’s topic and introduction to our special guest, Dave Lucia</li>\n<li>We
+    find out about Bitfo and what services they offer</li>\n<li>We discuss Dave’s
+    blog post on observability</li>\n<li>Find out how Dave wrote the blog post because
+    he saw a gap at his company</li>\n<li>How Sundi proofread Dave’s blog post and
+    realized her lack of knowledge on observability</li>\n<li>The most common mistake
+    teams or engineers make when it comes to observability</li>\n<li>We peel back
+    the layers on what telemetry is</li>\n<li>What the difference between telemetry
+    and OpenTelemetry is</li>\n<li>How to choose which tool is right when it comes
+    to better observability\n*The breakdown of the uses for observability telemetry\n*When
+    and why would we use OpenTelemtry vs basic observability\n*What languages Dave
+    started in before he was working in Elixir\n*How Elixir lends better for observability\n*Where
+    to start if you want to implement basic observability for someone who has no experience
+    with it\n*Dave answers the question, “can you go too far with observability?”\n*We
+    discuss Livebook and what exciting things it will bring for the future\n*Most
+    importantly, Dave explains why pineapples are important to him</li>\n</ul>\n\n<p>**Links
+    Mentioned in Today’s Episode:</p>\n\n<ul>\n<li>Dave’s blog post on Observability:
+    <a href=\"https://davelucia.com/blog/observing-elixir-with-lightstep\" rel=\"nofollow\">https://davelucia.com/blog/observing-elixir-with-lightstep</a></li>\n<li>Dave
+    Lucia on Twitter — <a href=\"https://twitter.com/davydog187\" rel=\"nofollow\">https://twitter.com/davydog187</a></li>\n<li>Dave
+    Lucia on GitHub — <a href=\"https://github.com/davydog187\" rel=\"nofollow\">https://github.com/davydog187</a></li>\n<li>Dave
+    Lucia on LinkedIn — <a href=\"https://www.linkedin.com/in/david-lucia-a395441b/\"
+    rel=\"nofollow\">https://www.linkedin.com/in/david-lucia-a395441b/</a></li>\n<li>Bitfo
+    — <a href=\"https://www.bitfo.com/\" rel=\"nofollow\">https://www.bitfo.com/</a></li>\n<li>SmartLogic
+    — <a href=\"https://smartlogic.io/\" rel=\"nofollow\">https://smartlogic.io/</a></li>\n</ul><p>Links:</p><ul><li><a
+    href=\"https://open.spotify.com/episode/3RmFXCjuVIsT1DqzqSZgAv?si=1c5d7a3171164223\"
+    title=\"Spotify\" rel=\"nofollow\">Spotify</a></li></ul>\n      "
 - title: We're baaaack! Season 9 Teaser
   slug: teasers9
   link: https://smartlogic.io/podcast/elixir-wizards/teasers9
   guid: e16cbd56-185c-4abf-a193-52a629580bc7
   pubDate: Thu, 22 Sep 2022 00:00:00 -0400
   pubDateFriendly: September 22, 2022
-  description: ''
+  description: "Hey everyone, Season 9 of Elixir Wizards is back! This season's theme
+    is Parsing the Particulars, where we dive into particular subjects with our guests.
+    Your returning hosts this season are Sundi, Owen and Dan! And we are excited to
+    announce that we have a new host joining the show - Bilal Hankins! Bilal is a
+    Software Developer at SmartLogic and is super excited to join us this season.
+    \nSome of this season's guests include Dave Lucia, CTO at Bitfo, Tyler Young,
+    Senior Software Developer at Felt, and Kate Rezentes, Junior Developer at SimpleBet.
+    Can't wait to see you there!\nSmartLogic — https://smartlogic.io/ \nSmartLogic
+    on Twitter — https://twitter.com/smartlogic\nSmartLogic on LinkedIn — https://www.linkedin.com/company/smartlogic-io/\nSmartLogic
+    on Facebook — https://www.facebook.com/smartlogic/\nBilal Hankins on LinkedIn
+    — https://www.linkedin.com/in/hankins-bilal/\nSundi Myint on LinkedIn — https://www.linkedin.com/in/sundimyint/\nOwen
+    Bickford on LinkedIn — https://www.linkedin.com/in/owen-bickford-8b6b1523a/\n"
   author: SmartLogic LLC
   embedUrl: https://fireside.fm/player/v2/IAs5ixts+TDzrU9qw
   enclosure:
@@ -138,9 +452,42 @@ items:
     duration: '1:07'
     explicit: 'no'
     keywords: 'elixir, tech, code '
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/e/e16cbd56-185c-4abf-a193-52a629580bc7/cover.jpg?v=1
-    summary: "\n        \n      "
-  contentEncoded: "\n        \n      "
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
+    summary: "\n        <p>Hey everyone, Season 9 of Elixir Wizards is back! This
+      season&#39;s theme is Parsing the Particulars, where we dive into particular
+      subjects with our guests. Your returning hosts this season are Sundi, Owen and
+      Dan! And we are excited to announce that we have a new host joining the show
+      - Bilal Hankins! Bilal is a Software Developer at SmartLogic and is super excited
+      to join us this season. </p>\n\n<p>Some of this season&#39;s guests include
+      Dave Lucia, CTO at Bitfo, Tyler Young, Senior Software Developer at Felt, and
+      Kate Rezentes, Junior Developer at SimpleBet. Can&#39;t wait to see you there!</p>\n\n<p>SmartLogic
+      — <a href=\"https://smartlogic.io/\" rel=\"nofollow\">https://smartlogic.io/</a>
+      <br>\nSmartLogic on Twitter — <a href=\"https://twitter.com/smartlogic\" rel=\"nofollow\">https://twitter.com/smartlogic</a><br>\nSmartLogic
+      on LinkedIn — <a href=\"https://www.linkedin.com/company/smartlogic-io/\" rel=\"nofollow\">https://www.linkedin.com/company/smartlogic-io/</a><br>\nSmartLogic
+      on Facebook — <a href=\"https://www.facebook.com/smartlogic/\" rel=\"nofollow\">https://www.facebook.com/smartlogic/</a><br>\nBilal
+      Hankins on LinkedIn — <a href=\"https://www.linkedin.com/in/hankins-bilal/\"
+      rel=\"nofollow\">https://www.linkedin.com/in/hankins-bilal/</a><br>\nSundi Myint
+      on LinkedIn — <a href=\"https://www.linkedin.com/in/sundimyint/\" rel=\"nofollow\">https://www.linkedin.com/in/sundimyint/</a><br>\nOwen
+      Bickford on LinkedIn — <a href=\"https://www.linkedin.com/in/owen-bickford-8b6b1523a/\"
+      rel=\"nofollow\">https://www.linkedin.com/in/owen-bickford-8b6b1523a/</a></p>\n
+      \     "
+  contentEncoded: "\n        <p>Hey everyone, Season 9 of Elixir Wizards is back!
+    This season&#39;s theme is Parsing the Particulars, where we dive into particular
+    subjects with our guests. Your returning hosts this season are Sundi, Owen and
+    Dan! And we are excited to announce that we have a new host joining the show -
+    Bilal Hankins! Bilal is a Software Developer at SmartLogic and is super excited
+    to join us this season. </p>\n\n<p>Some of this season&#39;s guests include Dave
+    Lucia, CTO at Bitfo, Tyler Young, Senior Software Developer at Felt, and Kate
+    Rezentes, Junior Developer at SimpleBet. Can&#39;t wait to see you there!</p>\n\n<p>SmartLogic
+    — <a href=\"https://smartlogic.io/\" rel=\"nofollow\">https://smartlogic.io/</a>
+    <br>\nSmartLogic on Twitter — <a href=\"https://twitter.com/smartlogic\" rel=\"nofollow\">https://twitter.com/smartlogic</a><br>\nSmartLogic
+    on LinkedIn — <a href=\"https://www.linkedin.com/company/smartlogic-io/\" rel=\"nofollow\">https://www.linkedin.com/company/smartlogic-io/</a><br>\nSmartLogic
+    on Facebook — <a href=\"https://www.facebook.com/smartlogic/\" rel=\"nofollow\">https://www.facebook.com/smartlogic/</a><br>\nBilal
+    Hankins on LinkedIn — <a href=\"https://www.linkedin.com/in/hankins-bilal/\" rel=\"nofollow\">https://www.linkedin.com/in/hankins-bilal/</a><br>\nSundi
+    Myint on LinkedIn — <a href=\"https://www.linkedin.com/in/sundimyint/\" rel=\"nofollow\">https://www.linkedin.com/in/sundimyint/</a><br>\nOwen
+    Bickford on LinkedIn — <a href=\"https://www.linkedin.com/in/owen-bickford-8b6b1523a/\"
+    rel=\"nofollow\">https://www.linkedin.com/in/owen-bickford-8b6b1523a/</a></p>\n
+    \     "
 - title: Looking back on Season 8 with Sundi, Owen & Dan
   slug: s8e12-finale
   link: https://smartlogic.io/podcast/elixir-wizards/s8e12-finale
@@ -185,7 +532,7 @@ items:
     duration: '38:23'
     explicit: 'no'
     keywords: ''
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/2/2cd157b4-8fcd-4025-9d56-76a10fb61903/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>It’s the season finale show! Can you believe it? Join us
       this week as Sundi, Owen, and Dan take a look back at this season of Elixir
       Wizards! You’ll hear their discussion about favorite moments over the season
@@ -272,7 +619,7 @@ items:
     duration: '29:11'
     explicit: 'no'
     keywords: ''
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/3/3d022fd3-b8f1-41da-97ac-8e9b5784bfa3/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>This week on Elixir Wizards we’re joined by Nathan Retta,
       Senior Software Engineer from Android at DoorDash. We learn about Nathan’s background;
       his experience having a degree in Chemical Engineering and working in Oil and
@@ -324,7 +671,7 @@ items:
     duration: '44:41'
     explicit: 'no'
     keywords: ''
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/a/acc26d2b-07e6-4dad-8ef5-e78780d17650/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Welcome to this week’s episode of Elixir Wizards, with
       our special guest, Cara Mitchell of Pepsi Co. Today we speak with Cara about
       her career journey that led to her living in the lower East Side of New York
@@ -401,7 +748,7 @@ items:
     duration: '42:48'
     explicit: 'no'
     keywords: ''
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/9/9114fce2-a423-4c1d-9ca6-c5ff2098dd34/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Joining us today on Elixir Wizards is Catalina Astengo,
       Staff Software Engineer at Nav Inc. We chat with Catalina about how she went
       from working as a process engineer in a mine to a software engineer in beautiful
@@ -553,7 +900,7 @@ items:
     duration: '45:35'
     explicit: 'no'
     keywords: ''
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/7/7a1f4173-df13-4237-9d32-e862b6512a16/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Welcome to another episode of Elixir Wizards, a show focused
       on conversations with software developers from around the world on the Elixir
       language and other modern web technologies. In today’s episode, we speak with
@@ -739,7 +1086,7 @@ items:
     duration: '43:42'
     explicit: 'no'
     keywords: ''
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/9/942f6a18-066a-4996-b3f8-9b0712959574/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>A superpower of software development is teaching our code
       to teach us what’s happening. This is observability, and it’s why Jessica Kerr
       works at Honeycomb, where she is a Developer Advocate. After twenty years as
@@ -915,7 +1262,7 @@ items:
     duration: '42:58'
     explicit: 'no'
     keywords: ''
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/c/c1e61882-d69a-47d8-af8b-a1a1b3f33708/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Welcome back to another episode of Elixir Wizards. Today,
       we chat with Digit, a talented software engineer currently based at SmartRent.
       He became aware of the company when he started trying to modify his smart home
@@ -1061,7 +1408,7 @@ items:
     duration: '45:20'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/2/23a28e9b-417e-4841-9b86-addd0247ce4e/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Joining us in conversation today is Nathan Willson all
       the way from Tokyo, Japan. Listeners will learn about the polyglot landscape
       he works in from Japan, why he believes knowing a language, and mastering it,
@@ -1195,7 +1542,7 @@ items:
     duration: '43:31'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/3/32849026-ad26-4b84-9a89-316306f6e3c1/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>This week we are joined by Sanne Kalkman, former teacher
       turned software engineer. Currently, Sanne works at CodeSandbox, where she&#39;s
       one of two Elixir developers responsible for the backend. When she&#39;s not
@@ -1355,7 +1702,7 @@ items:
     duration: '1:00:36'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/c/c1436a7a-59b9-402a-970c-f87791f275e1/cover.jpg?v=2
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>This double guest episode features Cassidy Williams, Head
       of Developer Experience and Education and Tobi Pfeiffer, Staff Engineer from
       Remote. This fast growing Elixir company provides HR support to clients who
@@ -1533,7 +1880,7 @@ items:
     duration: '48:07'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/9/95a396ef-84bd-43e0-b0ae-dc8276917eb9/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Today’s guest is Devon Estes, who leads the third-party
       integration team at Remote, a company that uses technology to make it easier
       for other companies to hire remote employees (not contractors, actual employees)
@@ -1659,7 +2006,7 @@ items:
     duration: '48:47'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/f/f4a94090-3527-4b5f-924e-beb55f9688c5/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Welcome to the new season of Elixir Wizards: Elixir in
       a Polyglot Environment. To get things going on this exciting and intriguing
       subject we are very happy to welcome Miguel Cobá! Miguel currently works at
@@ -1801,7 +2148,7 @@ items:
     duration: '56:55'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/8/8ddde7c8-d4df-4b6b-88dd-7ac7796534c1/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Welcome to the Season 7 finale! Today, we are joined by
       Todd Resudek, Staff Engineer at Jackpocket, to reflect on the past season and
       speak about the impact of Elixir, as well as a variety of other topics almost
@@ -1952,7 +2299,7 @@ items:
     duration: '45:33'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/d/d64b67ed-770e-44c1-8032-b2666cc84d48/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>This week we welcome Arthi Radhakrishnan back to the show
       to discuss how Elixir and her career more broadly have shaped her perspectives
       on learning. Arthi first got into programming as a child growing up in the Bay
@@ -2089,7 +2436,7 @@ items:
     duration: '51:20'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/a/a9b73218-2d0c-4a6f-9bba-93d5c355db7a/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Today we welcome software engineer Meryl Dakin to the show,
       who is currently employed by Knock. Meryl is here to help us continue our exploration
       of this season&#39;s theme of the impact of Elixir, and we get to hear about
@@ -2256,7 +2603,7 @@ items:
     duration: '46:05'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/6/66261581-0dd2-4380-8280-495736a41540/cover.jpg?v=2
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>We are very excited to welcome Brooklyn Zelenka back to
       the podcast to talk about her work at Fission and the ever-expanding frontier
       of edge computing! Brooklyn is a co-founder and CTO at Fission and she gives
@@ -2417,7 +2764,7 @@ items:
     duration: '50:42'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/b/bb8d89d6-4176-4414-b0fe-8e569cff9408/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>We are always excited to have conversations about the growth
       of the Elixir community, and today we go truly global, welcoming Sigu Magwa
       to the podcast, who hails from Kenya! Sigu is currently traveling in the US
@@ -2573,7 +2920,7 @@ items:
     duration: '56:10'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/c/c628b216-0cf4-431f-b430-377ad40bf4ff/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Brooklin Myers is on a quest to change the perception that
       Elixir is difficult to get into and we are so grateful to have him as a guest
       on the show today. Aside from being a passionate programmer, Brooklin spends
@@ -2723,7 +3070,7 @@ items:
     duration: '45:17'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/0/03563586-ac91-4c9e-a6ec-f7a91318d2b7/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>It is important to us that the Elixir community keeps thriving,
       and one of the best ways to ensure this is by lowering the barrier to entry
       as much as possible. Livebook is helping to achieve this aim, and today we are
@@ -2897,7 +3244,7 @@ items:
     duration: '42:11'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/4/496000a0-b38c-4ab6-96f8-a0948d8c6d40/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Today on the show we are grateful to get the chance to
       speak with Yiming Chen from Tubi, where we hear all about how he likes to use
       Elixir and the contributions he has made to the community. We begin as always
@@ -3061,7 +3408,7 @@ items:
     duration: '47:53'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/5/5c3a89b0-b7f6-4b83-aebb-af04520dba3e/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Today we are joined by programmer, professor, educator,
       and podcaster, Adolfo Neto! We have a fascinating conversation that continues
       our exploration of the theme of the impact of Elixir, hearing from Adolfo about
@@ -3225,7 +3572,7 @@ items:
     duration: '48:52'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/e/e7dec128-99fe-4b5f-9f1c-0844b6424558/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>As we continue this season of the podcast, focusing on
       the impact of Elixir, we are joined by Florian Kraft, all the way from Berlin,
       Germany! Florian works as a software engineer at Contentful, and has a number
@@ -3402,7 +3749,7 @@ items:
     duration: '47:57'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/1/196446c8-44e8-4c34-86c8-a688bfb3f706/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Today’s guest is Angel Jose, a Software Engineer Manager
       at Cars.com with a passion for product and the customer experience. Angel played
       a key role in completely re-platforming Cars.com via Elixir, Phoenix, and other
@@ -3542,7 +3889,7 @@ items:
     duration: '58:47'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/6/6610fc7c-e295-43f4-b542-40847c96f358/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>As we kick off our new, seventh season of the Elixir Wizards
       podcast, we wanted to introduce our theme of the impact of Elixir by having
       a simple chat between our panel and foregoing our usual guest format. As fans
@@ -3666,7 +4013,7 @@ items:
     duration: '57:56'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/5/5bcca27a-dc98-4584-a152-84f4b04ee0d5/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>We have reached the final episode of our season, and as
       we wrap up our exploration of BEAM magic, we are joined by Amos King, whose
       tweet was the inspiration behind this season&#39;s focus! We&#39;ve had such
@@ -3813,7 +4160,7 @@ items:
     duration: '38:30'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/3/332edbe7-b497-4b63-a474-8d468123d586/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>This episode serves as a round-up of some of the special
       mini-features we have recorded throughout Season 6, where we&#39;ll hear from
       Tyler Clemens, Elom Amouzou, Elise Navarro, and Jeremy Neal about their work
@@ -3988,7 +4335,7 @@ items:
     duration: '44:54'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/1/1487b980-5611-4fbc-9c58-7b4508ebefa9/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Joining us on the show today is Quinn Wilton, and we have
       a wonderful conversation with our guest about her journey with Elixir, unusual
       path into programming, and her wide appreciation for different languages! We
@@ -4141,7 +4488,7 @@ items:
     duration: '46:34'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/5/5e1ccc21-8727-4ae4-8921-ae296f46cff7/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>While NIFs provide a great way to interface with native
       code in the BEAM machine, the process can also be rather error-prone. Thankfully,
       since Isaac Yonemoto built Zigler, things have become a lot simpler, and he
@@ -4297,7 +4644,7 @@ items:
     duration: '50:13'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/f/ff944923-7612-4245-b9b0-d9217e878b0b/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Today we are so excited to share a conversation with Maxim
       Fedorov, who is the Core Infrastructure Lead at communications giant, WhatsApp!
       In our chat, Maxim offers such interesting insight and wisdom from a long career
@@ -4467,7 +4814,7 @@ items:
     duration: '48:08'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/4/49a8c965-5f19-4aba-9cd7-6b59acc7188b/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Some of you may recognize Chelsea Troy from her popular
       blog of the same name or as a keynote speaker for the March 2021 Code BEAM conference.
       Chelsea is an instructor in the Master&#39;s Program in Computer Science at
@@ -4643,7 +4990,7 @@ items:
     duration: '56:18'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/3/3cc0b619-ef6a-48ed-a0d6-8566f26ed0a9/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>While we can think of many reasons why we love Elixir,
       the community could always benefit from a more lively conversation around testing.
       It was with this in mind that Jeffrey Matthias and Andrea Leopardi decided to
@@ -4834,7 +5181,7 @@ items:
     duration: '46:33'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/3/3c07dbc2-eadc-48b9-9136-7decec7a0f57/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Joining us for this episode of Elixir Wizards is the vastly
       experienced and well-traveled Francesco Cesarini! Francesco is the founder of
       Erlang Solutions and we are so lucky to have him here on the show to talk about
@@ -5047,7 +5394,7 @@ items:
     duration: '54:11'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/9/95a7bb65-24d3-4155-bd40-9a4b4a94fbbb/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Today we have some extra BEAM magic for all of you! Joining
       us on the show is Chris Miller, who currently works as an Associate Software
       Engineer at Corvus Insurance. We get into a great conversation with Chris about
@@ -5238,7 +5585,7 @@ items:
     duration: '50:21'
     explicit: 'no'
     keywords: ''
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/9/943755c0-4bf5-4c89-949c-44406ea58584/cover.jpg?v=3
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>While there is magic to be found in many frameworks, having
       too much going on under the hood without you being able to control it is not
       for everybody. Today we invite Parker and Shannon Selbert to speak about their
@@ -5420,7 +5767,7 @@ items:
     duration: '1:00:41'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/f/f1486983-1421-45be-87ae-99a0a56ec848/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Today we are joined by the Vice President of Engineering
       at Corvus Insurance, Erik Person! Erik continues our journey into the magic
       of the BEAM, our season-long theme for the Elixir Wizards Podcast, and we get
@@ -5624,7 +5971,7 @@ items:
     duration: '49:38'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/1/10914181-66e0-4200-b6c8-260bee7e32bd/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Welcome to a brand-spanking-new season of Elixir Wizards!
       This time around we will be focussing on the magic of the BEAM, so get ready
       for an exciting journey into new territories filled with mystery and power!
@@ -5825,7 +6172,7 @@ items:
     duration: '1:01:39'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/1/12f603e4-7d53-4e83-baed-33e436cbf102/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Season 5 ends with a bang as we welcome back Sean Lewis,
       Anna Neyzber, and René Föhring onto the show to share their journey on getting
       their companies and teams to adopt Elixir. We open our conversation with each
@@ -6011,7 +6358,7 @@ items:
     duration: '47:38'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/2/2bb38486-078c-44b5-a40c-b2c71a50d210/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>The fields of data science and machine learning are moving
       ever faster. Jenn Gamble has her finger on the pulse and has become an industry
       expert with a wealth of experience to her name. As today’s guest, she dives
@@ -6179,7 +6526,7 @@ items:
     duration: '43:27'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/d/d761c5dd-b1bf-4062-a4e0-fe20d7c85e7f/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Many organizations take an incremental approach when adopting
       Elixir, preferring to pick up its nuances by using it to work on non-essential
       projects. But not Change.org. Today we speak with Change.org Director of Engineering
@@ -6366,7 +6713,7 @@ items:
     duration: '48:20'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/9/9470edd5-3447-4d40-9f5d-aaba34126ae3/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>As users increasingly demand interactivity from their web
       experiences, Phoenix LiveView is becoming the dominant way of writing interactive
       Elixir applications without a loss to reliability. Today we welcome back an
@@ -6574,7 +6921,7 @@ items:
     duration: '50:45'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/9/97fc73f8-1e61-447f-953f-99d2580f1476/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>With the prevalence of at-home learning, teachers have
       to compete for student attention against numerous screen-based activities. Today
       we speak with engineering lead Shaun Robinson and Elixir developer Toran Billups
@@ -6786,7 +7133,7 @@ items:
     duration: '59:23'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/1/1b9ca1de-dc95-49fa-885b-4e6093d52055/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>ClusterTruck, a master of vertical integration, is rewriting
       the method of end-to-end food delivery and ghost kitchens. Today we speak with
       ClusterTruck Product VP Brian Howenstein to find out more about his journey
@@ -6993,7 +7340,7 @@ items:
     duration: '55:46'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/b/bc908c5d-f422-4fc4-809b-ec4f4b051d3a/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Building a successful development company requires having
       a leader with technical know-how and excellent management skills. Today we speak
       with SmartLogic President and Founder Yair Flicker about his company’s origin
@@ -7157,7 +7504,7 @@ items:
     duration: '48:25'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/d/d3843a34-8180-4e29-ae31-ab4d2da8379b/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Despite its welcoming character, the Elixir community struggles
       with diversity; as the 2020 ElixirConf community survey shows, only 2% of Elixirists
       are women. Today we speak with Blinker software engineer Alexandra Chakeres
@@ -7328,7 +7675,7 @@ items:
     duration: '53:12'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/1/1752ae0e-feb0-4606-b3b0-97f70e29e3de/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>In this episode we continue our conversation about adopting
       Elixir, this time with Matt Nowack and Jake Heinz from Discord, hearing them
       get into the features of Elixir that make it a great fit for building a real-time
@@ -7507,7 +7854,7 @@ items:
     duration: '33:57'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/6/6475cfad-49d7-498d-a06a-c9af4a82e710/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Welcome back to the Elixir Wizards podcast! In this episode,
       we will be continuing our conversation on the theme of adopting elixir, and
       our great guest for today is Jason Axelson! Jason is a back-end developer for
@@ -7686,7 +8033,7 @@ items:
     duration: '38:33'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/6/6d2c98f6-1ba5-4003-8e4a-d98265dccd91/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Anyone who has written software for the travel industry
       can tell you that it is in desperate need of innovation — shockingly many of
       their cobwebbed systems were built in the 70s. Today we speak with Duffel CEO
@@ -7857,7 +8204,7 @@ items:
     duration: '38:57'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/a/a15c1f14-3ae4-4a02-a642-a03ab3e11660/cover.jpg?v=2
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>To beat out their competitors, startups need to code quickly,
       simply, and in a language that attracts top engineers. Enter Elixir. Today we
       speak with Shawn Vo, Axle Payments Co-Founder and CTO, about his journey with
@@ -8049,7 +8396,7 @@ items:
     duration: '47:20'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/6/6e5cd223-dc2c-42ee-9c40-d7e778b4ee9b/cover.jpg?v=2
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Today we sit down with Erlanger Viktória Fördős, who talks
       with us about Erlang and how it is used at Cisco. We open the show by finding
       out about Viki’s background in coding and her unorthodox entry into the field.
@@ -8254,7 +8601,7 @@ items:
     duration: '37:27'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/4/4653eb7c-8637-447c-8ead-a6fe53e5c3cc/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Today’s guest is Simon Glenn-Gregg, News Engineer at The
       Washington Post. He joins us to talk about using Elixir to build a prototype
       for a platform the news house recently implemented to visualize the results
@@ -8468,7 +8815,7 @@ items:
     duration: '53:09'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/4/41c6ea5d-4915-4a6e-9795-3e2a9b57aa72/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>The culture of your programming community directly impacts
       your professional success. As Thunderbolt Labs Founder Randall Thomas explains
       in this episode, a community that practices openness and which warmly welcomes
@@ -8688,7 +9035,7 @@ items:
     duration: '56:34'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/4/4a9a2637-46ff-42d5-af60-6c46bbf9c3fa/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Welcome back to Elixir Wizards, season five, episode one!
       The theme for this season is ‘Adopting Elixir’, and for today’s show the team
       at Elixir Outlaws play host! Chris Keathley, Amos King, and Anna Neyzberg give
@@ -8877,7 +9224,7 @@ items:
     duration: '59:12'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/8/8cbeff8e-7468-4da6-a117-7e0a1f94d653/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>To close off this season and conclude our deep dive into
       system and application architecture, today’s episode is a special panel discussion
       on a topic that has provoked a mix of answers that range from the controversial
@@ -9086,7 +9433,7 @@ items:
     duration: '35:16'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/6/6cb1796f-017c-4f06-bd10-9cbf85fff404/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Even with the most programming experience in the world,
       coding still involves a lot of trial and error. People getting started in the
       industry should not become bogged down by failure. Because in the end, it’s
@@ -9269,7 +9616,7 @@ items:
     duration: '48:36'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/b/b59ac59d-736e-4581-b0c0-e04adeb1ba91/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>There is no difference between architecture and design.
       It&#39;s all engineering and creating a distinction between the two is a way
       for someone to get paid more and have a different title. That hot take comes
@@ -9466,7 +9813,7 @@ items:
     duration: '48:24'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/a/a61dcf3a-a8e5-45c7-a648-6994628ce9ec/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Imagine being hired into a rocketship startup using Elixir
       as its primary language. And all this, straight out of college. Today, we speak
       with systems software engineer, Lizzie Paquette who works at Brex, the aforementioned
@@ -9723,7 +10070,7 @@ items:
     duration: '49:09'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/7/7070efa5-519a-4d9b-ac5a-75cfc1882a31/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Building a sophisticated AI that can evolve to fit our
       vast and diverse needs is a Herculean challenge. Today we speak with senior
       engineer Eric Steen about Automata, his experimental Elixir project that uses
@@ -9983,7 +10330,7 @@ items:
     duration: '42:29'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/4/441f7029-d8ab-4494-aa7b-cfb08e4ade23/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>According to an ancient myth, the world rests on the back
       of a turtle. And what does that turtle stand on? Another turtle. It turns out
       that it’s turtles all the way down. Miki Rezentes, today’s guest, believes that
@@ -10274,7 +10621,7 @@ items:
     duration: '1:17:12'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/a/a233d61f-e572-4479-a477-18b0d08fb053/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>With ElixirConf 2020 just around the corner, today’s episode
       is a sneak peek where we talk with six of this year’s speakers. Each speaker
       gives listeners an elevator pitch of their talk while throwing in extra details
@@ -10654,7 +11001,7 @@ items:
     duration: '58:51'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/e/e18fef05-5ebe-42a1-9317-b193dfa84cd2/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Domain-driven design and extreme programming can help bridge
       the gap between development and business, and today we invite Mark Windholtz
       from Agile DNA to talk about how! Mark starts out by telling us about his early
@@ -10894,7 +11241,7 @@ items:
     duration: '42:41'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/6/6cf32d50-909b-4839-a690-0fdc8ec48a2f/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Welcome to the second part of our special Elixir Wizards
       Dojo. A mashup made in partnership with ElixirConf Japan. In today’s episode,
       we talk to Nerves core team members Todd Resudek and Connor Rigby about all
@@ -11163,7 +11510,7 @@ items:
     duration: '54:17'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/9/96d50b65-bc90-434e-ae8b-96b7c9f3990d/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Welcome to the first part of our extra special Elixir Wizards
       Dojo. A mashup made in partnership with ElixirConf Japan, in today’s episode,
       we pose questions asked by the Japanese Nerves community to Nerves core team
@@ -11396,7 +11743,7 @@ items:
     duration: '41:43'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/f/f66990d4-1466-41eb-aa79-c89d644f8d94/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>In today’s episode, we chat about system architecture,
       Ruby, Elixir, and everything in between with Greg Mefford, the senior back-end
       engineer for the Bleacher Report. We open the conversation by asking Greg about
@@ -11632,7 +11979,7 @@ items:
     duration: '49:14'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/1/1b6e0936-69df-48a0-83aa-42c3302bcb0a/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Johanna Larsson is a community-minded software engineer
       whose project, Hex Diff, generates highlighted git diffs, right in your browser.
       In this episode, we talk to Johanna about how Hex Diff can benefit Elixir users,
@@ -11857,7 +12204,7 @@ items:
     duration: '37:32'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/f/f39e6147-f6c0-4c1e-803f-d128bfbec255/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Handling date and time is a challenge in any language,
       but Lau Taarnskov is determined to solve that problem in Elixir. Lau is today’s
       guest on Elixir Wizards, and this episode is all about his contributions to
@@ -12043,7 +12390,7 @@ items:
     duration: '55:09'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/e/e9769249-24cb-455c-9983-011f1c414d3d/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>For part 2 of our Council of Wizards panel discussion,
       we are joined by Chris Bell, Desmond Bowe, Emily Maxie, Dan Lindeman, and Alan
       Voss! Chris and Desmond run the ElixirTalk Podcast and we get in-depth on the
@@ -12230,7 +12577,7 @@ items:
     duration: '39:28'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/2/2e71b35e-54cc-4bfe-be34-6567c5fb448c/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>The Elixir community continues to flourish and evolve in
       these uncertain times and in honor of this we have put together a live show
       with a number of special guests! In part one today, we are joined by Andrea
@@ -12403,7 +12750,7 @@ items:
     duration: '43:42'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/c/c87149f2-e430-4fcb-8e22-e3242c625e1b/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Although it’s taken him four seasons to make an appearance,
       we are so glad to finally welcome Chris McCord, creator of the Phoenix framework,
       onto the show. While this season’s focus is on system and application architecture,
@@ -12587,7 +12934,7 @@ items:
     duration: '55:23'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/c/c4183a48-6039-4dc1-b54b-c43973086490/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Today’s guest is Amos King, Principal CEO at Binary Noggin,
       and host on the Elixir Outlaws and This Agile Life podcasts. This episode is
       centered around a casual conversation about everything from programming, the
@@ -12759,7 +13106,7 @@ items:
     duration: '45:58'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/f/f14188bd-903b-49eb-bc8b-f52429966e63/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Welcome to another episode of Elixir Wizards as we continue
       our journey into system and application architecture! Our featured guest today
       is Sundi Myint and she is here to share her journey with Elixir and her non-traditional
@@ -12975,7 +13322,7 @@ items:
     duration: '1:09:43'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/9/9f7ee6f5-a587-4f63-9fc5-ec4cdca6676f/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Dave Thomas is recognized internationally as an expert
       who develops high-quality software–accurate and highly flexible systems. He
       helped write the now-famous Agile Manifesto, and regularly gives inspiring and
@@ -13168,7 +13515,7 @@ items:
     duration: '38:27'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/e/e711fb4d-502b-4733-b5e2-01ff002b836a/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Joining us on the show for this episode is Ben Marx, author
       of Adopting Elixir and Principal Control Plane Engineer at the recently launched
       SubSpace! We continue our Season 4 journey into system and application architecture
@@ -13303,7 +13650,7 @@ items:
     duration: '14:46'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/a/ac3f0d31-f498-4d6a-ba69-3dbae9d0510f/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>A special episode of Elixir Wizards highlighting Pattern
       Matching with Todd - a short format interview where our friend, Todd Resudek,
       asks different guests the same five questions. This week Todd spoke with Johanna
@@ -13388,7 +13735,7 @@ items:
     duration: '49:26'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/b/b07768d6-b987-496e-87d3-483eedd42fa5/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Real-time applications come with real challenges—persistent
       connections, multi-server deployment, and strict performance requirements are
       just a few. Our guest today is Steve Bussey, a software architect at SalesLoft
@@ -13528,7 +13875,7 @@ items:
     duration: '43:22'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/a/a3a16821-cb7c-4c88-be0e-c2b412ad7bee/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Today’s guest is Mohd Maqbool Alam, a software developer
       and Elixir fan from Delhi. He enjoys learning about programming language theory,
       distributed systems, Cloud Native technologies, and open source. As he is working
@@ -13705,7 +14052,7 @@ items:
     duration: '1:09:36'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/3/34c3c1af-3f50-4e83-be65-e7420d65eada/cover.jpg?v=2
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>As our first trilogy comes to a close, and we embark on
       the next one, we’re doing what all great trilogies do: Upending everything that
       made the initial one great and starting afresh. We have taken on board some
@@ -13947,7 +14294,7 @@ items:
     duration: '53:26'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/d/dbe34c01-2361-41a8-ab85-dab81699cc7e/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Welcome back to part two of our betweenisode! Everybody
       is working remotely now including ourselves, so today we continue the catch
       ups we were having with a number of longstanding buddies and chat about life
@@ -14206,7 +14553,7 @@ items:
     duration: '53:16'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/1/1b54b0cf-efaa-46fa-90b5-e40411069750/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>The world has changed so much since the end of season 3,
       that we thought we’d put together a special Betweenisode to tide you over until
       Season 4 launches. In this episode, we talk to several friends and respected
@@ -14424,7 +14771,7 @@ items:
     duration: '50:45'
     explicit: 'no'
     keywords: elixir,phoenix,erlang
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/3/36812119-eef7-40f5-8aba-3fd7b3bebb09/cover.jpg?v=2
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>In this episode, we take a look into the current contexts
       and home lives many of us find ourselves in today, offering top tips for working
       remotely from home during these challenging times. The lockdowns have caused
@@ -14587,7 +14934,7 @@ items:
     duration: '53:54'
     explicit: 'no'
     keywords: elixir,phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/1/19db794e-cf88-4320-969b-ea0ccbe0949d/cover.jpg?v=2
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Welcome to another extra special episode of Elixir Wizards!
       We have guest hosts today, Meryl Dakin of Frame.io and Sophie DeBenedetto of
       Github, and they welcome Steven Nunez, Staff Engineer at the Flatiron School,
@@ -14745,7 +15092,7 @@ items:
     duration: '51:01'
     explicit: 'no'
     keywords: elixir, phoenix, erlang
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/7/75204e87-33b5-4a39-833c-d2a7f5ae1931/cover.jpg?v=2
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Saša Jurić is a household name in the Elixir and Erlang
       space and we are so glad to finally welcome him on to the show today! Author
       of Elixir in Action, Saša is here to discuss training and his thoughts on getting
@@ -14881,7 +15228,7 @@ items:
     duration: '46:44'
     explicit: 'no'
     keywords: elixir, phoenix, lonestar elixir
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg?v=3
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Elixir Outlaws invited us to join them for a special crossover
       episode, recorded live at Lonestar Elixir 2020. Join us for a conversation around
       fun and learning in development, highlights from day one of the conference,
@@ -14978,7 +15325,7 @@ items:
     duration: '48:34'
     explicit: 'no'
     keywords: elixir, ruby, benchee, pandas, erlang
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/6/65360c15-6a60-4c48-be76-94f642cb6869/cover.jpg?v=2
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Our guest today, Devon Estes, approached us about the possible
       opportunity for Elixir to optimize and build out the pandas data analysis and
       manipulation tool, sharing why he thinks it would be a valuable addition to
@@ -15152,7 +15499,7 @@ items:
     duration: '53:38'
     explicit: 'no'
     keywords: lonestar elixir, elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/4/49808f09-dc08-407e-9d3b-9db8f0bbff97/cover.jpg?v=2
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Welcome back to the show for this special edition Lunchisode,
       coming to you live from the Lonestar Elixir 2020 Conference! We have a revolving
       door of speakers at this informal roundtable and a few friends and associates
@@ -15325,7 +15672,7 @@ items:
     duration: '1:10:46'
     explicit: 'no'
     keywords: elixir, phoenix, lonestar
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/1/10fa47c2-0223-46ac-a69d-465fd1393edb/cover.jpg?v=2
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>This week we&#39;re delighted to share a special format
       bonus episode! </p>\n\n<p>We are joined by guest co-host Todd Resudek as well
       as a number of guests who each share a little bit about what they&#39;re working
@@ -15519,7 +15866,7 @@ items:
     duration: '26:11'
     explicit: 'no'
     keywords: DockYard, elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/1/1cd7d8f6-8965-4bd2-b159-1580e133bb6f/cover.jpg?v=2
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Today on the show, we’re joined by Mike Binns and Alex
       Garibay of DockYard. In this episode, Mike and Alex share their journeys of
       how they came to work at DockYard and give us a view into DockYard’s hiring
@@ -15675,7 +16022,7 @@ items:
     duration: '34:34'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/3/37389f65-249a-4e59-bdac-c71a646d2b23/cover.jpg?v=2
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Today on Elixir Wizards we are delighted to be joined by
       Sean Lewis, a senior backend architect at Divvy. One of the many impressive
       facts about Sean is that he is entirely self-taught, from dabbling in Python
@@ -15840,7 +16187,7 @@ items:
     duration: '51:59'
     explicit: 'no'
     keywords: elixir, lumen, rust
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/5/5c493edc-c294-4fdd-b9f9-86a091800d96/cover.jpg?v=2
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>In line with our current working-with-Elixir theme, today
       we’re talking about performance with Paul Schoenfelder and Hans Elias Josephsen
       from DockYard. The two have been working on Lumen, and in this episode, they
@@ -15987,7 +16334,7 @@ items:
     duration: '45:12'
     explicit: 'no'
     keywords: elixir, 2U,Frame.io,github
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/3/37d41249-7185-40c3-a4c3-3d761103ed16/cover.jpg?v=2
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Today on the show we are joined by Sophie DeBenedetto from
       GitHub and Meryl Dakin from Frame.io to talk about the processes involved in
       training others and building Elixir projects. They share about studying and
@@ -16155,7 +16502,7 @@ items:
     duration: '39:26'
     explicit: 'no'
     keywords: elixir, phoenix, fission
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/5/590ef7b4-3a91-4c74-9325-2568d7adecdb/cover.jpg?v=2
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>In today’s episode we have one of our favorite recurring
       guests, Brooklyn Zelenka, joining us once again! Brooklyn has been on the show
       in both the first and second seasons to speak about Elixir and functional programming.
@@ -16305,7 +16652,7 @@ items:
     duration: '38:04'
     explicit: 'no'
     keywords: elixir, phoenix, groxio, lonestar elixir
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/f/f54652e5-c7c3-4165-9c4b-0ddd2ca2d14b/cover.jpg?v=2
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Groxio is a great platform that allows programmers to learn
       new languages easily and broaden their horizons. Our guests today are the team
       behind Groxio, Bruce and Maggie Tate! In our discussion, we cover the basics
@@ -16439,7 +16786,7 @@ items:
     duration: '22:39'
     explicit: 'no'
     keywords: ''
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/e/ea443f10-25a6-4570-9fe8-20e7f6624671/cover.jpg?v=2
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>On today&#39;s show, we are joined by Dan Ivovich from
       our team here at SmartLogic! Dan is the Director of Development Operations and
       has already been a guest and cohost a few times on the show. Today we are talking
@@ -16601,7 +16948,7 @@ items:
     duration: '37:10'
     explicit: 'no'
     keywords: hex, elixir, mint
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/e/ef0d105d-13f1-4803-8837-341f56782510/cover.jpg?v=2
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>We are happy to be joined in this episode by Eric Meadows
       Jönsson, creator of the hexpm package manager, and an amazing resource who works
       tirelessly to build the Elixir community. Eric presently works at Brex and was
@@ -16824,7 +17171,7 @@ items:
     duration: '35:26'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/b/b26cdd89-0d68-4466-9714-44c278932651/cover.jpg?v=2
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Our guest on the show today is blogger, software cowboy,
       and podcast host Chris Keathley. Chris is a senior engineer at Bleacher Report,
       co-host of Elixir Outlaws, and writer of an assemblage of open-source software.
@@ -17013,7 +17360,7 @@ items:
     duration: '38:47'
     explicit: 'no'
     keywords: elixir, nerves, erlang
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/2/2be72d78-cfcc-46e2-a0a5-753fc8a0c280/cover.jpg?v=2
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>On today’s show, we welcome Justin Schneck and Frank Hunleth,
       luminaries from the Nerves team! We take a dive into the world of Nerves with
       them, covering themes of performance, problem-solving, transitioning to hardware,
@@ -17156,7 +17503,7 @@ items:
     duration: '27:21'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/f/f816f14f-9675-4d38-a622-24dd6eb29cd1/cover.jpg?v=2
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Our theme this season is working with Elixir, and joining
       in the conversation today is Brad Traylor from Podium. Brad shares his expertise
       in hiring and training for Podium, a position he is passionate about since it
@@ -17296,7 +17643,7 @@ items:
     duration: '43:40'
     explicit: 'no'
     keywords: elixir
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/1/13faacd6-6639-4fe7-a552-5f58e3dc2f3d/cover.jpg?v=3
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Today on Elixir Wizards we are joined by none other than
       José Valim, the inventor of Elixir! Coming from the Ruby on Rails world, José
       found his way to functional programming and we hear all about the evolution
@@ -17423,7 +17770,7 @@ items:
     duration: '25:40'
     explicit: 'no'
     keywords: elixirconf, functional programming, elixir
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/7/7f21096c-8f00-4f06-9b4a-a0a8b554e28b/cover.jpg?v=2
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Welcome to Elixir Wizards, today we are joined by Dr. Jim
       Freeze to talk about his passion for and history in Elixir and functional programming.
       Dr. Freeze is one of the organizers of one of our favorite things in the world,
@@ -17543,7 +17890,7 @@ items:
     duration: '11:53'
     explicit: 'no'
     keywords: ''
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg?v=3
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Welcome to the last episode of Season 2 of the podcast!
       We are taking this opportunity to recap what we covered in the season and talk
       about what we liked and what we didn&#39;t like so much. We do not have a guest
@@ -17668,7 +18015,7 @@ items:
     duration: '32:31'
     explicit: 'no'
     keywords: elixir, rustler, rust, elm, simplebet
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/1/1f938053-676b-4137-ad82-f104ebda9488/cover.jpg?v=3
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Our guest today on the show is Dave Lucia, who is currently
       the Vice President of Engineering at SimpleBet. He is here as part of Elixir
       Internals series, to talk to us and all our listeners about Rustler and the
@@ -17793,7 +18140,7 @@ items:
     duration: '29:26'
     explicit: 'no'
     keywords: exventure
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/0/0a947a18-82f2-4b2e-8c0c-69696c5980d9/cover.jpg?v=3
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>This season on Smart Software Season 2, we are focused
       on the inner workings of Elixir and the inner workings of popular Elixir libraries,
       or Elixir internals. Today, I have the pleasure of interviewing my colleague,
@@ -17890,7 +18237,7 @@ items:
     duration: '30:42'
     explicit: 'no'
     keywords: ''
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/7/7b360fac-dde4-44a4-b637-762e19a0274b/cover.jpg?v=3
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Welcome to another episode of the podcast everybody! As
       we continue our journey into Elixir internals in Season 2, we welcome Sophie
       DeBenedetto to tell us about the two libraries she and the Flatiron School created!
@@ -18028,7 +18375,7 @@ items:
     duration: '28:57'
     explicit: 'no'
     keywords: ''
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/e/ec6a1593-38d7-48b0-8494-9dd83f8f6cff/cover.jpg?v=3
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Today on the show we welcome Shanti Chellaram to talk about
       a couple of Erlang libraries she has created! We hear from her about Pri-Queue
       and raft_erl, and her motivation behind making them and some of the things we
@@ -18178,7 +18525,7 @@ items:
     duration: '27:31'
     explicit: 'no'
     keywords: elixir, erlang, ecto, jason
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/d/d20c39c5-2b6c-44a9-96ff-0dff754dd08f/cover.jpg?v=3
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Today on the show we are joined by Michal Muskala, who
       is currently a freelance software engineer and he is here to talk to us about
       his work on the Ecto and jason libraries. With Ecto we continue our journey
@@ -18319,7 +18666,7 @@ items:
     duration: '34:00'
     explicit: 'no'
     keywords: ''
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/2/2ebfdc2e-d967-4324-bcbe-de67bccb57e6/cover.jpg?v=3
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Today on the show we get stuck into the inner workings
       of Hex 1.0 and are happy to be joined by returning guest, Todd Resudek. As you
       might already know, Todd is the Senior Software Engineer at Weedmaps, a regular
@@ -18439,7 +18786,7 @@ items:
     duration: '26:46'
     explicit: 'no'
     keywords: ''
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/3/37e3efb0-85b7-4dd9-bbf9-a997b01c6437/cover.jpg?v=3
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>In this episode of the podcast we are joined by Chris Keathley
       to continue our exploration of Elixir internals as he tells us about two very
       popular libraries that he developed, Wallaby and Raft. We start off with some
@@ -18568,7 +18915,7 @@ items:
     duration: '29:36'
     explicit: 'no'
     keywords: elixir, credo
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/9/9532d3dd-1d07-4ac9-b4c8-3f1580deff11/cover.jpg?v=3
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Welcome back to the SmartLogic Podcast where we talk about
       the latest developments and best practices in the web and mobile software industry.
       In continuing with our theme of Elixir Internals, we’re having a conversation
@@ -18706,7 +19053,7 @@ items:
     duration: '27:31'
     explicit: 'no'
     keywords: elixir, wework, flatiron school, token alchemist
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/3/3050865c-0418-42d6-ade9-9605af11fee6/cover.jpg?v=3
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Today on the show we continue our series on the inner workings
       of several different Elixir libraries and are happy to be joined by Meryl Dakin,
       Software Engineer at the Flatiron School and author of Token Alchemist. In this
@@ -18829,7 +19176,7 @@ items:
     duration: '29:45'
     explicit: 'no'
     keywords: elixir, distillery
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/b/bd39f088-71c3-4425-b78e-8fc4a5324a1c/cover.jpg?v=3
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Welcome back to show everyone and today in our exploration
       of Elixir libraries we are talking to Paul Schoenfelder! He is here to unpack
       Distillery, his own creation from the world of Elixir and tell us about how
@@ -18943,7 +19290,7 @@ items:
     duration: '23:56'
     explicit: 'no'
     keywords: elixir, elixirscript, the big elixir
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/e/ed1a46a8-a3ac-4808-b1e5-91e950b2791a/cover.jpg?v=3
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Today on the show we continue our series on the inner workings
       and various libraries of Elixir and are very happy to welcome Bryan Joseph of
       Revelry to talk about his very own ElixirScript. ElixirScript is essentially
@@ -19072,7 +19419,7 @@ items:
     duration: '30:15'
     explicit: 'no'
     keywords: elixir, witchcraft, dialyzer
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/4/490b7cc3-44d7-4917-9688-2450d18de62a/cover.jpg?v=3
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Hey everybody and welcome back to Season 2 of the podcast!
       This season we will be talking about Elixir internals, libraries and the inner
       workings of the language. In our first episode we are very happy to be joined
@@ -19180,7 +19527,7 @@ items:
     duration: '20:03'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg?v=3
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>With this season over, we bring Dan Ivovich back to talk
       about what we learned.</p>\n\n<p>Dan Ivovich - Director of Development Operations
       @ SmartLogic</p>\n\n<p>00:43 - Why are you using Elixir in production?<br>\n01:20
@@ -19239,7 +19586,7 @@ items:
     duration: '43:54'
     explicit: 'no'
     keywords: elixir, phoenix, production
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/7/7bd99e2e-cba0-4c94-904a-5486ce48c517/cover.jpg?v=2
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>We talk with Jeffrey Matthias from Community about their
       current and past Elixir projects and how they are deployed.</p>\n\n<p>Jeffrey
       Matthias - <a href=\"https://www.community.com/\" rel=\"nofollow\">Community</a></p>\n\n<p>Find
@@ -19412,7 +19759,7 @@ items:
     duration: '17:25'
     explicit: 'no'
     keywords: elixir, phoenix, production
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/c/c300841a-d5b9-4957-950f-ce0f6bc3af68/cover.jpg?v=2
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>We talk with Jay Ashe from Cava about their current and
       past Elixir projects and how they are deployed.</p>\n\n<p>Jay Ashe - <a href=\"https://cava.com/\"
       rel=\"nofollow\">Cava</a></p>\n\n<p>Find Jay elsewhere online:<br>\n<a href=\"https://twitter.com/jgashe\"
@@ -19659,7 +20006,7 @@ items:
     duration: '28:47'
     explicit: 'no'
     keywords: elixir, nerves, production
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/a/ad538aa5-ad67-418b-b07f-0be38fff2f6b/cover.jpg?v=2
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>We talk with Frank Hunleth from the Nerves core team about
       their current and past Elixir projects and how they are deployed.</p>\n\n<p>Frank
       Hunleth - <a href=\"https://nerves-project.org/\" rel=\"nofollow\">Nerves</a></p>\n\n<p>Find
@@ -19741,7 +20088,7 @@ items:
     duration: '36:34'
     explicit: 'no'
     keywords: elixir, phoenix, production
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/4/4a5a2fb4-c1a0-437a-9001-9b981312ecab/cover.jpg?v=2
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>We talk with Mark Ericksen from Elixir Mix about their
       current and past Elixir projects and how they are deployed.</p>\n\n<p>Mark Ericksen
       - <a href=\"https://devchat.tv/elixir-mix/\" rel=\"nofollow\">Elixir Mix</a></p>\n\n<p>Find
@@ -19854,7 +20201,7 @@ items:
     duration: '27:46'
     explicit: 'no'
     keywords: elixir, phoenix, spade co
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/0/0cef68be-a246-4ba6-bdc7-a6835c05fe72/cover.jpg?v=2
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>We talk with Brooklyn Zelenka from SPADE Co. about their
       current and past Elixir projects and how they are deployed.</p>\n\n<p>Brooklyn
       Zelenka - <a href=\"https://spade.builders/\" rel=\"nofollow\">SPADE Co.</a></p>\n\n<p>Find
@@ -19966,7 +20313,7 @@ items:
     duration: '26:01'
     explicit: 'no'
     keywords: elixir, phoenix, weedmaps
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/d/d949b81e-39c5-4474-8605-89062b8dc543/cover.jpg?v=2
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>We talk with Todd Resudek from Weedmaps about their current
       Elixir projects and how they are deployed.</p>\n\n<p>Todd Resudek - <a href=\"https://weedmaps.com/\"
       rel=\"nofollow\">Weedmaps</a></p>\n\n<p>Find Todd elsewhere online:<br>\n<a
@@ -20053,7 +20400,7 @@ items:
     duration: '49:26'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/4/4646981d-f12c-479e-a5cc-7629570962ed/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>We sat down with numerous developers, including José Valim
       and Chris McCord, during the Saturday lunch at <a href=\"https://lonestarelixir.com/2019/\"
       rel=\"nofollow\">Lonestar ElixirConf 2019</a>. Hear what they had to say about
@@ -20149,7 +20496,7 @@ items:
     duration: '32:34'
     explicit: 'no'
     keywords: elixir, phoenix, clustertruck
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/9/9b17b0c6-6e66-4e77-ae1f-9b3e2db6a35b/cover.jpg?v=3
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>We talk with Ryan Billingsley from ClusterTruck about their
       current Elixir projects and how they are deployed.</p>\n\n<p>Ryan Billingsley
       - <a href=\"https://www.clustertruck.com/\" rel=\"nofollow\">ClusterTruck</a></p>\n\n<p>Find
@@ -20269,7 +20616,7 @@ items:
     duration: '28:28'
     explicit: 'no'
     keywords: elixir, phoenix, smartlogic
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/f/f71af757-ce4c-44a0-8e78-5766711fd7d4/cover.jpg?v=2
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>We talk with developers from the team here at SmartLogic
       about our current practices on deploying Elixir and Phoenix in production.</p>\n\n<p>Dan
       Ivovich - Director of Development Operations @ SmartLogic</p>\n\n<p>Learn more
@@ -20418,12 +20765,12 @@ itunes:
   summary: "Elixir Wizards is an interview-format podcast, focused on engineers who
     use the Elixir programming language. Initially launched in early 2019, each season
     focuses on a specific topic or topics, with each interview focusing on the guest's
-    experience and opinions on the topic.\nElixir Wizards is hosted by Alex Housand,
-    Sundi Myint, and Eric Oestrich of SmartLogic, a dev shop that’s been building
+    experience and opinions on the topic.\nElixir Wizards is hosted by Sundi Myint,
+    Owen Bickford, and Bilal Hankins of SmartLogic, a dev shop that’s been building
     custom software since 2005 and running Elixir applications in production since
     2015.\nLearn more about how SmartLogic uses Phoenix and Elixir. (https://smartlogic.io/phoenix-and-elixir?utm_source=podcast)
     \n"
-  image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg?v=3
+  image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
   explicit: 'no'
   keywords: elixir, elixirlang, phoenix, web apps, mobile apps, webdev, software development
   owner:

--- a/_data/elixir_wizards_seasons.yml
+++ b/_data/elixir_wizards_seasons.yml
@@ -61,7 +61,7 @@ Season 3:
     duration: '50:45'
     explicit: 'no'
     keywords: elixir,phoenix,erlang
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/3/36812119-eef7-40f5-8aba-3fd7b3bebb09/cover.jpg?v=2
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>In this episode, we take a look into the current contexts
       and home lives many of us find ourselves in today, offering top tips for working
       remotely from home during these challenging times. The lockdowns have caused
@@ -224,7 +224,7 @@ Season 3:
     duration: '53:54'
     explicit: 'no'
     keywords: elixir,phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/1/19db794e-cf88-4320-969b-ea0ccbe0949d/cover.jpg?v=2
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Welcome to another extra special episode of Elixir Wizards!
       We have guest hosts today, Meryl Dakin of Frame.io and Sophie DeBenedetto of
       Github, and they welcome Steven Nunez, Staff Engineer at the Flatiron School,
@@ -382,7 +382,7 @@ Season 3:
     duration: '51:01'
     explicit: 'no'
     keywords: elixir, phoenix, erlang
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/7/75204e87-33b5-4a39-833c-d2a7f5ae1931/cover.jpg?v=2
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Saša Jurić is a household name in the Elixir and Erlang
       space and we are so glad to finally welcome him on to the show today! Author
       of Elixir in Action, Saša is here to discuss training and his thoughts on getting
@@ -518,7 +518,7 @@ Season 3:
     duration: '46:44'
     explicit: 'no'
     keywords: elixir, phoenix, lonestar elixir
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg?v=3
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Elixir Outlaws invited us to join them for a special crossover
       episode, recorded live at Lonestar Elixir 2020. Join us for a conversation around
       fun and learning in development, highlights from day one of the conference,
@@ -615,7 +615,7 @@ Season 3:
     duration: '48:34'
     explicit: 'no'
     keywords: elixir, ruby, benchee, pandas, erlang
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/6/65360c15-6a60-4c48-be76-94f642cb6869/cover.jpg?v=2
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Our guest today, Devon Estes, approached us about the possible
       opportunity for Elixir to optimize and build out the pandas data analysis and
       manipulation tool, sharing why he thinks it would be a valuable addition to
@@ -789,7 +789,7 @@ Season 3:
     duration: '53:38'
     explicit: 'no'
     keywords: lonestar elixir, elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/4/49808f09-dc08-407e-9d3b-9db8f0bbff97/cover.jpg?v=2
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Welcome back to the show for this special edition Lunchisode,
       coming to you live from the Lonestar Elixir 2020 Conference! We have a revolving
       door of speakers at this informal roundtable and a few friends and associates
@@ -962,7 +962,7 @@ Season 3:
     duration: '1:10:46'
     explicit: 'no'
     keywords: elixir, phoenix, lonestar
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/1/10fa47c2-0223-46ac-a69d-465fd1393edb/cover.jpg?v=2
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>This week we&#39;re delighted to share a special format
       bonus episode! </p>\n\n<p>We are joined by guest co-host Todd Resudek as well
       as a number of guests who each share a little bit about what they&#39;re working
@@ -1156,7 +1156,7 @@ Season 3:
     duration: '26:11'
     explicit: 'no'
     keywords: DockYard, elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/1/1cd7d8f6-8965-4bd2-b159-1580e133bb6f/cover.jpg?v=2
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Today on the show, we’re joined by Mike Binns and Alex
       Garibay of DockYard. In this episode, Mike and Alex share their journeys of
       how they came to work at DockYard and give us a view into DockYard’s hiring
@@ -1312,7 +1312,7 @@ Season 3:
     duration: '34:34'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/3/37389f65-249a-4e59-bdac-c71a646d2b23/cover.jpg?v=2
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Today on Elixir Wizards we are delighted to be joined by
       Sean Lewis, a senior backend architect at Divvy. One of the many impressive
       facts about Sean is that he is entirely self-taught, from dabbling in Python
@@ -1477,7 +1477,7 @@ Season 3:
     duration: '51:59'
     explicit: 'no'
     keywords: elixir, lumen, rust
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/5/5c493edc-c294-4fdd-b9f9-86a091800d96/cover.jpg?v=2
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>In line with our current working-with-Elixir theme, today
       we’re talking about performance with Paul Schoenfelder and Hans Elias Josephsen
       from DockYard. The two have been working on Lumen, and in this episode, they
@@ -1624,7 +1624,7 @@ Season 3:
     duration: '45:12'
     explicit: 'no'
     keywords: elixir, 2U,Frame.io,github
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/3/37d41249-7185-40c3-a4c3-3d761103ed16/cover.jpg?v=2
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Today on the show we are joined by Sophie DeBenedetto from
       GitHub and Meryl Dakin from Frame.io to talk about the processes involved in
       training others and building Elixir projects. They share about studying and
@@ -1792,7 +1792,7 @@ Season 3:
     duration: '39:26'
     explicit: 'no'
     keywords: elixir, phoenix, fission
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/5/590ef7b4-3a91-4c74-9325-2568d7adecdb/cover.jpg?v=2
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>In today’s episode we have one of our favorite recurring
       guests, Brooklyn Zelenka, joining us once again! Brooklyn has been on the show
       in both the first and second seasons to speak about Elixir and functional programming.
@@ -1942,7 +1942,7 @@ Season 3:
     duration: '38:04'
     explicit: 'no'
     keywords: elixir, phoenix, groxio, lonestar elixir
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/f/f54652e5-c7c3-4165-9c4b-0ddd2ca2d14b/cover.jpg?v=2
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Groxio is a great platform that allows programmers to learn
       new languages easily and broaden their horizons. Our guests today are the team
       behind Groxio, Bruce and Maggie Tate! In our discussion, we cover the basics
@@ -2076,7 +2076,7 @@ Season 3:
     duration: '22:39'
     explicit: 'no'
     keywords: ''
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/e/ea443f10-25a6-4570-9fe8-20e7f6624671/cover.jpg?v=2
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>On today&#39;s show, we are joined by Dan Ivovich from
       our team here at SmartLogic! Dan is the Director of Development Operations and
       has already been a guest and cohost a few times on the show. Today we are talking
@@ -2238,7 +2238,7 @@ Season 3:
     duration: '37:10'
     explicit: 'no'
     keywords: hex, elixir, mint
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/e/ef0d105d-13f1-4803-8837-341f56782510/cover.jpg?v=2
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>We are happy to be joined in this episode by Eric Meadows
       Jönsson, creator of the hexpm package manager, and an amazing resource who works
       tirelessly to build the Elixir community. Eric presently works at Brex and was
@@ -2461,7 +2461,7 @@ Season 3:
     duration: '35:26'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/b/b26cdd89-0d68-4466-9714-44c278932651/cover.jpg?v=2
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Our guest on the show today is blogger, software cowboy,
       and podcast host Chris Keathley. Chris is a senior engineer at Bleacher Report,
       co-host of Elixir Outlaws, and writer of an assemblage of open-source software.
@@ -2650,7 +2650,7 @@ Season 3:
     duration: '38:47'
     explicit: 'no'
     keywords: elixir, nerves, erlang
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/2/2be72d78-cfcc-46e2-a0a5-753fc8a0c280/cover.jpg?v=2
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>On today’s show, we welcome Justin Schneck and Frank Hunleth,
       luminaries from the Nerves team! We take a dive into the world of Nerves with
       them, covering themes of performance, problem-solving, transitioning to hardware,
@@ -2793,7 +2793,7 @@ Season 3:
     duration: '27:21'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/f/f816f14f-9675-4d38-a622-24dd6eb29cd1/cover.jpg?v=2
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Our theme this season is working with Elixir, and joining
       in the conversation today is Brad Traylor from Podium. Brad shares his expertise
       in hiring and training for Podium, a position he is passionate about since it
@@ -2933,7 +2933,7 @@ Season 3:
     duration: '43:40'
     explicit: 'no'
     keywords: elixir
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/1/13faacd6-6639-4fe7-a552-5f58e3dc2f3d/cover.jpg?v=3
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Today on Elixir Wizards we are joined by none other than
       José Valim, the inventor of Elixir! Coming from the Ruby on Rails world, José
       found his way to functional programming and we hear all about the evolution
@@ -3060,7 +3060,7 @@ Season 3:
     duration: '25:40'
     explicit: 'no'
     keywords: elixirconf, functional programming, elixir
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/7/7f21096c-8f00-4f06-9b4a-a0a8b554e28b/cover.jpg?v=2
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Welcome to Elixir Wizards, today we are joined by Dr. Jim
       Freeze to talk about his passion for and history in Elixir and functional programming.
       Dr. Freeze is one of the organizers of one of our favorite things in the world,
@@ -3154,7 +3154,7 @@ Season 3:
     duration: '1:40'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg?v=3
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Welcome back to Season 3! Our theme this time around is
       Working with Elixir. Listen for more on our theme, upcoming guests, and our
       new name.</p>\n      "
@@ -3211,7 +3211,7 @@ Season 2:
     duration: '11:53'
     explicit: 'no'
     keywords: ''
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg?v=3
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Welcome to the last episode of Season 2 of the podcast!
       We are taking this opportunity to recap what we covered in the season and talk
       about what we liked and what we didn&#39;t like so much. We do not have a guest
@@ -3336,7 +3336,7 @@ Season 2:
     duration: '32:31'
     explicit: 'no'
     keywords: elixir, rustler, rust, elm, simplebet
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/1/1f938053-676b-4137-ad82-f104ebda9488/cover.jpg?v=3
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Our guest today on the show is Dave Lucia, who is currently
       the Vice President of Engineering at SimpleBet. He is here as part of Elixir
       Internals series, to talk to us and all our listeners about Rustler and the
@@ -3461,7 +3461,7 @@ Season 2:
     duration: '29:26'
     explicit: 'no'
     keywords: exventure
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/0/0a947a18-82f2-4b2e-8c0c-69696c5980d9/cover.jpg?v=3
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>This season on Smart Software Season 2, we are focused
       on the inner workings of Elixir and the inner workings of popular Elixir libraries,
       or Elixir internals. Today, I have the pleasure of interviewing my colleague,
@@ -3558,7 +3558,7 @@ Season 2:
     duration: '30:42'
     explicit: 'no'
     keywords: ''
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/7/7b360fac-dde4-44a4-b637-762e19a0274b/cover.jpg?v=3
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Welcome to another episode of the podcast everybody! As
       we continue our journey into Elixir internals in Season 2, we welcome Sophie
       DeBenedetto to tell us about the two libraries she and the Flatiron School created!
@@ -3696,7 +3696,7 @@ Season 2:
     duration: '28:57'
     explicit: 'no'
     keywords: ''
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/e/ec6a1593-38d7-48b0-8494-9dd83f8f6cff/cover.jpg?v=3
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Today on the show we welcome Shanti Chellaram to talk about
       a couple of Erlang libraries she has created! We hear from her about Pri-Queue
       and raft_erl, and her motivation behind making them and some of the things we
@@ -3846,7 +3846,7 @@ Season 2:
     duration: '27:31'
     explicit: 'no'
     keywords: elixir, erlang, ecto, jason
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/d/d20c39c5-2b6c-44a9-96ff-0dff754dd08f/cover.jpg?v=3
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Today on the show we are joined by Michal Muskala, who
       is currently a freelance software engineer and he is here to talk to us about
       his work on the Ecto and jason libraries. With Ecto we continue our journey
@@ -3987,7 +3987,7 @@ Season 2:
     duration: '34:00'
     explicit: 'no'
     keywords: ''
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/2/2ebfdc2e-d967-4324-bcbe-de67bccb57e6/cover.jpg?v=3
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Today on the show we get stuck into the inner workings
       of Hex 1.0 and are happy to be joined by returning guest, Todd Resudek. As you
       might already know, Todd is the Senior Software Engineer at Weedmaps, a regular
@@ -4107,7 +4107,7 @@ Season 2:
     duration: '26:46'
     explicit: 'no'
     keywords: ''
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/3/37e3efb0-85b7-4dd9-bbf9-a997b01c6437/cover.jpg?v=3
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>In this episode of the podcast we are joined by Chris Keathley
       to continue our exploration of Elixir internals as he tells us about two very
       popular libraries that he developed, Wallaby and Raft. We start off with some
@@ -4236,7 +4236,7 @@ Season 2:
     duration: '29:36'
     explicit: 'no'
     keywords: elixir, credo
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/9/9532d3dd-1d07-4ac9-b4c8-3f1580deff11/cover.jpg?v=3
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Welcome back to the SmartLogic Podcast where we talk about
       the latest developments and best practices in the web and mobile software industry.
       In continuing with our theme of Elixir Internals, we’re having a conversation
@@ -4374,7 +4374,7 @@ Season 2:
     duration: '27:31'
     explicit: 'no'
     keywords: elixir, wework, flatiron school, token alchemist
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/3/3050865c-0418-42d6-ade9-9605af11fee6/cover.jpg?v=3
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Today on the show we continue our series on the inner workings
       of several different Elixir libraries and are happy to be joined by Meryl Dakin,
       Software Engineer at the Flatiron School and author of Token Alchemist. In this
@@ -4497,7 +4497,7 @@ Season 2:
     duration: '29:45'
     explicit: 'no'
     keywords: elixir, distillery
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/b/bd39f088-71c3-4425-b78e-8fc4a5324a1c/cover.jpg?v=3
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Welcome back to show everyone and today in our exploration
       of Elixir libraries we are talking to Paul Schoenfelder! He is here to unpack
       Distillery, his own creation from the world of Elixir and tell us about how
@@ -4611,7 +4611,7 @@ Season 2:
     duration: '23:56'
     explicit: 'no'
     keywords: elixir, elixirscript, the big elixir
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/e/ed1a46a8-a3ac-4808-b1e5-91e950b2791a/cover.jpg?v=3
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Today on the show we continue our series on the inner workings
       and various libraries of Elixir and are very happy to welcome Bryan Joseph of
       Revelry to talk about his very own ElixirScript. ElixirScript is essentially
@@ -4740,7 +4740,7 @@ Season 2:
     duration: '30:15'
     explicit: 'no'
     keywords: elixir, witchcraft, dialyzer
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/4/490b7cc3-44d7-4917-9688-2450d18de62a/cover.jpg?v=3
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Hey everybody and welcome back to Season 2 of the podcast!
       This season we will be talking about Elixir internals, libraries and the inner
       workings of the language. In our first episode we are very happy to be joined
@@ -4836,7 +4836,7 @@ Season 2:
     duration: '1:26'
     explicit: 'no'
     keywords: ''
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg?v=3
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>We’re excited to announce our season two topic, Elixir
       Internals. In this season we talk with developers behind some of the most popular
       Elixir libraries, including Witchcraft, ElixirScript, Distillery, Ecto, and
@@ -4883,7 +4883,7 @@ Season 1:
     duration: '20:03'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg?v=3
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>With this season over, we bring Dan Ivovich back to talk
       about what we learned.</p>\n\n<p>Dan Ivovich - Director of Development Operations
       @ SmartLogic</p>\n\n<p>00:43 - Why are you using Elixir in production?<br>\n01:20
@@ -4942,7 +4942,7 @@ Season 1:
     duration: '43:54'
     explicit: 'no'
     keywords: elixir, phoenix, production
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/7/7bd99e2e-cba0-4c94-904a-5486ce48c517/cover.jpg?v=2
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>We talk with Jeffrey Matthias from Community about their
       current and past Elixir projects and how they are deployed.</p>\n\n<p>Jeffrey
       Matthias - <a href=\"https://www.community.com/\" rel=\"nofollow\">Community</a></p>\n\n<p>Find
@@ -5115,7 +5115,7 @@ Season 1:
     duration: '17:25'
     explicit: 'no'
     keywords: elixir, phoenix, production
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/c/c300841a-d5b9-4957-950f-ce0f6bc3af68/cover.jpg?v=2
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>We talk with Jay Ashe from Cava about their current and
       past Elixir projects and how they are deployed.</p>\n\n<p>Jay Ashe - <a href=\"https://cava.com/\"
       rel=\"nofollow\">Cava</a></p>\n\n<p>Find Jay elsewhere online:<br>\n<a href=\"https://twitter.com/jgashe\"
@@ -5362,7 +5362,7 @@ Season 1:
     duration: '28:47'
     explicit: 'no'
     keywords: elixir, nerves, production
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/a/ad538aa5-ad67-418b-b07f-0be38fff2f6b/cover.jpg?v=2
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>We talk with Frank Hunleth from the Nerves core team about
       their current and past Elixir projects and how they are deployed.</p>\n\n<p>Frank
       Hunleth - <a href=\"https://nerves-project.org/\" rel=\"nofollow\">Nerves</a></p>\n\n<p>Find
@@ -5444,7 +5444,7 @@ Season 1:
     duration: '36:34'
     explicit: 'no'
     keywords: elixir, phoenix, production
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/4/4a5a2fb4-c1a0-437a-9001-9b981312ecab/cover.jpg?v=2
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>We talk with Mark Ericksen from Elixir Mix about their
       current and past Elixir projects and how they are deployed.</p>\n\n<p>Mark Ericksen
       - <a href=\"https://devchat.tv/elixir-mix/\" rel=\"nofollow\">Elixir Mix</a></p>\n\n<p>Find
@@ -5557,7 +5557,7 @@ Season 1:
     duration: '27:46'
     explicit: 'no'
     keywords: elixir, phoenix, spade co
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/0/0cef68be-a246-4ba6-bdc7-a6835c05fe72/cover.jpg?v=2
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>We talk with Brooklyn Zelenka from SPADE Co. about their
       current and past Elixir projects and how they are deployed.</p>\n\n<p>Brooklyn
       Zelenka - <a href=\"https://spade.builders/\" rel=\"nofollow\">SPADE Co.</a></p>\n\n<p>Find
@@ -5669,7 +5669,7 @@ Season 1:
     duration: '26:01'
     explicit: 'no'
     keywords: elixir, phoenix, weedmaps
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/d/d949b81e-39c5-4474-8605-89062b8dc543/cover.jpg?v=2
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>We talk with Todd Resudek from Weedmaps about their current
       Elixir projects and how they are deployed.</p>\n\n<p>Todd Resudek - <a href=\"https://weedmaps.com/\"
       rel=\"nofollow\">Weedmaps</a></p>\n\n<p>Find Todd elsewhere online:<br>\n<a
@@ -5756,7 +5756,7 @@ Season 1:
     duration: '49:26'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/4/4646981d-f12c-479e-a5cc-7629570962ed/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>We sat down with numerous developers, including José Valim
       and Chris McCord, during the Saturday lunch at <a href=\"https://lonestarelixir.com/2019/\"
       rel=\"nofollow\">Lonestar ElixirConf 2019</a>. Hear what they had to say about
@@ -5872,7 +5872,7 @@ Season 1:
     duration: '28:28'
     explicit: 'no'
     keywords: elixir, phoenix, smartlogic
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/f/f71af757-ce4c-44a0-8e78-5766711fd7d4/cover.jpg?v=2
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>We talk with developers from the team here at SmartLogic
       about our current practices on deploying Elixir and Phoenix in production.</p>\n\n<p>Dan
       Ivovich - Director of Development Operations @ SmartLogic</p>\n\n<p>Learn more
@@ -6061,7 +6061,7 @@ Season 1:
     duration: '32:34'
     explicit: 'no'
     keywords: elixir, phoenix, clustertruck
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/9/9b17b0c6-6e66-4e77-ae1f-9b3e2db6a35b/cover.jpg?v=3
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>We talk with Ryan Billingsley from ClusterTruck about their
       current Elixir projects and how they are deployed.</p>\n\n<p>Ryan Billingsley
       - <a href=\"https://www.clustertruck.com/\" rel=\"nofollow\">ClusterTruck</a></p>\n\n<p>Find
@@ -6141,7 +6141,7 @@ Season 1:
     duration: '1:24'
     explicit: 'no'
     keywords: elixir, phoenix, production
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg?v=3
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Welcome to the first season of Smart Software with SmartLogic.
       We&#39;ll be interviewing several companies about how they use Elixir in Production
       this season. In this preview episode, we introduce ourselves and some of the
@@ -6155,13 +6155,327 @@ Season 1:
     uses <a href=\"https://smr.tl/2Hyslu8\" rel=\"nofollow\">Phoenix and Elixir.</a></p>\n
     \     "
 Season 9:
+- title: 'Tyler Young on Geo Mapping at Felt '
+  slug: s9e3-tyleryoung-felt
+  link: https://smartlogic.io/podcast/elixir-wizards/s9e3-tyleryoung-felt
+  guid: 457bc018-a109-4457-b7bd-693ebd2ef38e
+  pubDate: Thu, 13 Oct 2022 06:00:00 -0400
+  pubDateFriendly: October 13, 2022
+  description: "Today on Elixir Wizards we are joined by Tyler Young to explore the
+    particulars of Geo Mapping, the process of turning data into maps. Tyler is a
+    Senior Software Developer at Felt, the world’s first collaborative mapping tool
+    built for anyone to make a beautiful map in minutes. Tune in today to learn more
+    about Geo Mapping from today’s special guest, Tyler Young!\nKey Points From This
+    Episode:\nA brief breakdown of today’s topic and introduction to our special guest,
+    Tyler Young\nWe discover Tyler’s background and how he started working in Elixir,
+    as well as how he got into the map business because of his love for Elixir \nWe
+    learn about GIS and its history as a system/standard/protocol, and how someone
+    can study GIS \nFind out how mapping is helpful in more ways than just for directions,
+    including climate changes, vacation planning, and more\nTyler breaks down the
+    common technologies and toolkits for programming with maps \nThe specific tools
+    that Felt is using to ingest map data and build the interactive maps \nWhat common
+    problems arise when developing with maps\nTyler teaches the Elixir Wizards about
+    his tried and true way of decision making with “The McDonald’s option” \n_\n**Links
+    Mentioned in Today’s Episode:\nTyler Young on Twitter — https://twitter.com/TylerAYoung\nTyler
+    Young on GitHub — https://github.com/s3cur3\nTyler Young on LinkedIn — https://www.linkedin.com/in/tyler-young-dev/\nFelt
+    — https://felt.com/about\nSmartLogic — https://smartlogic.io/\nSmartLogic Twitter
+    — https://twitter.com/smartlogic\n"
+  author: SmartLogic LLC
+  embedUrl: https://fireside.fm/player/v2/IAs5ixts+373p2LD-
+  enclosure:
+    url: https://aphid.fireside.fm/d/1437767933/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/457bc018-a109-4457-b7bd-693ebd2ef38e.mp3
+    length: '31075529'
+    type: audio/mpeg
+  itunes:
+    episodeType: full
+    season: '9'
+    author: SmartLogic LLC
+    subtitle: Today on Elixir Wizards we are joined by Tyler Young to explore the
+      particulars of Geo Mapping, the process of turning data into maps. Tyler is
+      a Senior Software Developer at Felt, the world’s first collaborative mapping
+      tool built for anyone to make a beautiful map in minutes. Tune in today to learn
+      more about Geo Mapping from today’s special guest, Tyler Young!
+    duration: '36:59'
+    explicit: 'no'
+    keywords: elixir, geo mapping, tech, felt
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
+    summary: "\n        <p>Today on Elixir Wizards we are joined by Tyler Young to
+      explore the particulars of Geo Mapping, the process of turning data into maps.
+      Tyler is a Senior Software Developer at Felt, the world’s first collaborative
+      mapping tool built for anyone to make a beautiful map in minutes. Tune in today
+      to learn more about Geo Mapping from today’s special guest, Tyler Young!</p>\n\n<p>Key
+      Points From This Episode:</p>\n\n<ul>\n<li>A brief breakdown of today’s topic
+      and introduction to our special guest, Tyler Young</li>\n<li>We discover Tyler’s
+      background and how he started working in Elixir, as well as how he got into
+      the map business because of his love for Elixir </li>\n<li>We learn about GIS
+      and its history as a system/standard/protocol, and how someone can study GIS
+      </li>\n<li>Find out how mapping is helpful in more ways than just for directions,
+      including climate changes, vacation planning, and more</li>\n<li>Tyler breaks
+      down the common technologies and toolkits for programming with maps </li>\n<li>The
+      specific tools that Felt is using to ingest map data and build the interactive
+      maps </li>\n<li>What common problems arise when developing with maps</li>\n<li><p>Tyler
+      teaches the Elixir Wizards about his tried and true way of decision making with
+      “The McDonald’s option” <br>\n_<br>\n**Links Mentioned in Today’s Episode:</p></li>\n<li><p>Tyler
+      Young on Twitter — <a href=\"https://twitter.com/TylerAYoung\" rel=\"nofollow\">https://twitter.com/TylerAYoung</a></p></li>\n<li><p>Tyler
+      Young on GitHub — <a href=\"https://github.com/s3cur3\" rel=\"nofollow\">https://github.com/s3cur3</a></p></li>\n<li><p>Tyler
+      Young on LinkedIn — <a href=\"https://www.linkedin.com/in/tyler-young-dev/\"
+      rel=\"nofollow\">https://www.linkedin.com/in/tyler-young-dev/</a></p></li>\n<li><p>Felt
+      — <a href=\"https://felt.com/about\" rel=\"nofollow\">https://felt.com/about</a></p></li>\n<li><p>SmartLogic
+      — <a href=\"https://smartlogic.io/\" rel=\"nofollow\">https://smartlogic.io/</a></p></li>\n<li><p>SmartLogic
+      Twitter — <a href=\"https://twitter.com/smartlogic\" rel=\"nofollow\">https://twitter.com/smartlogic</a></p></li>\n</ul>\n
+      \     "
+  contentEncoded: "\n        <p>Today on Elixir Wizards we are joined by Tyler Young
+    to explore the particulars of Geo Mapping, the process of turning data into maps.
+    Tyler is a Senior Software Developer at Felt, the world’s first collaborative
+    mapping tool built for anyone to make a beautiful map in minutes. Tune in today
+    to learn more about Geo Mapping from today’s special guest, Tyler Young!</p>\n\n<p>Key
+    Points From This Episode:</p>\n\n<ul>\n<li>A brief breakdown of today’s topic
+    and introduction to our special guest, Tyler Young</li>\n<li>We discover Tyler’s
+    background and how he started working in Elixir, as well as how he got into the
+    map business because of his love for Elixir </li>\n<li>We learn about GIS and
+    its history as a system/standard/protocol, and how someone can study GIS </li>\n<li>Find
+    out how mapping is helpful in more ways than just for directions, including climate
+    changes, vacation planning, and more</li>\n<li>Tyler breaks down the common technologies
+    and toolkits for programming with maps </li>\n<li>The specific tools that Felt
+    is using to ingest map data and build the interactive maps </li>\n<li>What common
+    problems arise when developing with maps</li>\n<li><p>Tyler teaches the Elixir
+    Wizards about his tried and true way of decision making with “The McDonald’s option”
+    <br>\n_<br>\n**Links Mentioned in Today’s Episode:</p></li>\n<li><p>Tyler Young
+    on Twitter — <a href=\"https://twitter.com/TylerAYoung\" rel=\"nofollow\">https://twitter.com/TylerAYoung</a></p></li>\n<li><p>Tyler
+    Young on GitHub — <a href=\"https://github.com/s3cur3\" rel=\"nofollow\">https://github.com/s3cur3</a></p></li>\n<li><p>Tyler
+    Young on LinkedIn — <a href=\"https://www.linkedin.com/in/tyler-young-dev/\" rel=\"nofollow\">https://www.linkedin.com/in/tyler-young-dev/</a></p></li>\n<li><p>Felt
+    — <a href=\"https://felt.com/about\" rel=\"nofollow\">https://felt.com/about</a></p></li>\n<li><p>SmartLogic
+    — <a href=\"https://smartlogic.io/\" rel=\"nofollow\">https://smartlogic.io/</a></p></li>\n<li><p>SmartLogic
+    Twitter — <a href=\"https://twitter.com/smartlogic\" rel=\"nofollow\">https://twitter.com/smartlogic</a></p></li>\n</ul>\n
+    \     "
+- title: Kate Rezentes on GenServers at Simplebet
+  slug: s9e2-kate-rezentes-simplebet
+  link: https://smartlogic.io/podcast/elixir-wizards/s9e2-kate-rezentes-simplebet
+  guid: 7bcfea5b-42f1-4dc9-9384-3b37f432a636
+  pubDate: Thu, 06 Oct 2022 06:00:00 -0400
+  pubDateFriendly: October  6, 2022
+  description: "Season 9 is in full swing and we are so excited to welcome Kate Rezentes
+    today to dive into the particulars of GenServers. Kate is a Junior Software Developer
+    at Simplebet, a B2B product development company using machine learning and real-time
+    technology to make every moment of every sporting event a betting opportunity.
+    Tune in today to learn more from today’s special guest, Kate Rezentes!\nKey Points
+    From This Episode:\n A brief breakdown of today’s topic and introduction to our
+    special guest, Kate Rezentes \n We learn about Kate’s background and her long
+    history with programming\nWe discuss how many conferences she’s attended and why
+    ElixirConf has been her favorite (thus far)\n Find out how Kate landed a job while
+    attending ElixirConf\n How GenServers as a subject came to be\nWe get an inside
+    look at Kate’s working experience at Simplebet and her experience as a Junior
+    Engineer in the industry so far \nWhat cases in particular cause the need for
+    a GenServer\nWe discuss where GenServers would be appropriate to use and why\nThe
+    ins and outs of ‘handle calls’ and ‘callbacks’\nThe process of testing a GenServer
+    and data storage_\n**Links Mentioned in Today’s Episode:*\nKate Rezentes on Twitter
+    — https://twitter.com/rezkate\nKate Rezentes on GitHub — https://github.com/KateRezentes\nKate
+    Rezentes on LinkedIn — https://www.linkedin.com/in/kfrezent/\nSimplebet — https://simplebet.io/\nSmartLogic
+    — https://smartlogic.io/\nSmartLogic Twitter — https://twitter.com/smartlogic\n"
+  author: SmartLogic LLC
+  embedUrl: https://fireside.fm/player/v2/IAs5ixts+TZBECxVc
+  enclosure:
+    url: https://aphid.fireside.fm/d/1437767933/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/7bcfea5b-42f1-4dc9-9384-3b37f432a636.mp3
+    length: '46206464'
+    type: audio/mpeg
+  itunes:
+    episodeType: full
+    season: '9'
+    author: SmartLogic LLC
+    subtitle: Season 9 is in full swing and we are so excited to welcome Kate Rezentes
+      today to dive into the particulars of GenServers. Kate is a Junior Software
+      Developer at Simplebet, a B2B product development company using machine learning
+      and real-time technology to make every moment of every sporting event a betting
+      opportunity. Tune in today to learn more from today’s special guest, Kate Rezentes!
+    duration: '48:07'
+    explicit: 'no'
+    keywords: simplebet, genservers, elixir, smartlogic
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
+    summary: "\n        <p>Season 9 is in full swing and we are so excited to welcome
+      Kate Rezentes today to dive into the particulars of GenServers. Kate is a Junior
+      Software Developer at Simplebet, a B2B product development company using machine
+      learning and real-time technology to make every moment of every sporting event
+      a betting opportunity. Tune in today to learn more from today’s special guest,
+      Kate Rezentes!</p>\n\n<p>Key Points From This Episode:</p>\n\n<ul>\n<li> A brief
+      breakdown of today’s topic and introduction to our special guest, Kate Rezentes
+      </li>\n<li> We learn about Kate’s background and her long history with programming</li>\n<li>We
+      discuss how many conferences she’s attended and why ElixirConf has been her
+      favorite (thus far)</li>\n<li> Find out how Kate landed a job while attending
+      ElixirConf</li>\n<li> How GenServers as a subject came to be</li>\n<li>We get
+      an inside look at Kate’s working experience at Simplebet and her experience
+      as a Junior Engineer in the industry so far </li>\n<li>What cases in particular
+      cause the need for a GenServer</li>\n<li>We discuss where GenServers would be
+      appropriate to use and why</li>\n<li>The ins and outs of ‘handle calls’ and
+      ‘callbacks’</li>\n<li>The process of testing a GenServer and data storage_</li>\n</ul>\n\n<p><em>**Links
+      Mentioned in Today’s Episode:</em>*</p>\n\n<ul>\n<li>Kate Rezentes on Twitter
+      — <a href=\"https://twitter.com/rezkate\" rel=\"nofollow\">https://twitter.com/rezkate</a></li>\n<li>Kate
+      Rezentes on GitHub — <a href=\"https://github.com/KateRezentes\" rel=\"nofollow\">https://github.com/KateRezentes</a></li>\n<li>Kate
+      Rezentes on LinkedIn — <a href=\"https://www.linkedin.com/in/kfrezent/\" rel=\"nofollow\">https://www.linkedin.com/in/kfrezent/</a></li>\n<li>Simplebet
+      — <a href=\"https://simplebet.io/\" rel=\"nofollow\">https://simplebet.io/</a></li>\n<li>SmartLogic
+      — <a href=\"https://smartlogic.io/\" rel=\"nofollow\">https://smartlogic.io/</a></li>\n<li>SmartLogic
+      Twitter — <a href=\"https://twitter.com/smartlogic\" rel=\"nofollow\">https://twitter.com/smartlogic</a></li>\n</ul>\n
+      \     "
+  contentEncoded: "\n        <p>Season 9 is in full swing and we are so excited to
+    welcome Kate Rezentes today to dive into the particulars of GenServers. Kate is
+    a Junior Software Developer at Simplebet, a B2B product development company using
+    machine learning and real-time technology to make every moment of every sporting
+    event a betting opportunity. Tune in today to learn more from today’s special
+    guest, Kate Rezentes!</p>\n\n<p>Key Points From This Episode:</p>\n\n<ul>\n<li>
+    A brief breakdown of today’s topic and introduction to our special guest, Kate
+    Rezentes </li>\n<li> We learn about Kate’s background and her long history with
+    programming</li>\n<li>We discuss how many conferences she’s attended and why ElixirConf
+    has been her favorite (thus far)</li>\n<li> Find out how Kate landed a job while
+    attending ElixirConf</li>\n<li> How GenServers as a subject came to be</li>\n<li>We
+    get an inside look at Kate’s working experience at Simplebet and her experience
+    as a Junior Engineer in the industry so far </li>\n<li>What cases in particular
+    cause the need for a GenServer</li>\n<li>We discuss where GenServers would be
+    appropriate to use and why</li>\n<li>The ins and outs of ‘handle calls’ and ‘callbacks’</li>\n<li>The
+    process of testing a GenServer and data storage_</li>\n</ul>\n\n<p><em>**Links
+    Mentioned in Today’s Episode:</em>*</p>\n\n<ul>\n<li>Kate Rezentes on Twitter
+    — <a href=\"https://twitter.com/rezkate\" rel=\"nofollow\">https://twitter.com/rezkate</a></li>\n<li>Kate
+    Rezentes on GitHub — <a href=\"https://github.com/KateRezentes\" rel=\"nofollow\">https://github.com/KateRezentes</a></li>\n<li>Kate
+    Rezentes on LinkedIn — <a href=\"https://www.linkedin.com/in/kfrezent/\" rel=\"nofollow\">https://www.linkedin.com/in/kfrezent/</a></li>\n<li>Simplebet
+    — <a href=\"https://simplebet.io/\" rel=\"nofollow\">https://simplebet.io/</a></li>\n<li>SmartLogic
+    — <a href=\"https://smartlogic.io/\" rel=\"nofollow\">https://smartlogic.io/</a></li>\n<li>SmartLogic
+    Twitter — <a href=\"https://twitter.com/smartlogic\" rel=\"nofollow\">https://twitter.com/smartlogic</a></li>\n</ul>\n
+    \     "
+- title: Dave Lucia on Observability at Bitfo
+  slug: s9e1-dave-lucia-bitfo
+  link: https://smartlogic.io/podcast/elixir-wizards/s9e1-dave-lucia-bitfo
+  guid: ccdb0e5d-3009-44db-9573-d5a5a12696eb
+  pubDate: Thu, 29 Sep 2022 03:00:00 -0400
+  pubDateFriendly: September 29, 2022
+  description: |
+    Welcome to our first episode of Season 9 Elixir Wizards, Parsing the Particulars. A show focused on conversations with software developers from around the world on the Elixir language and other modern web technologies. Today, we are joined by Dave Lucia, Chief Technology Officer at Bitfo, a cryptocurrency media company building educational content for people who are interested in cryptocurrency. Dave is active in the Elixir community and in the past has spoken at Code BEAM SF, ElixirConf, RabbitMQ Summit, and has written several blog posts which can be found at davelucia.com. In today’s episode we find out more about Dave’s professional background and dive into the particulars of observability. Tune in today to learn more from today’s special guest, Dave Lucia!
+    Key Points From This Episode:
+    A brief breakdown of today’s topic and introduction to our special guest, Dave Lucia
+    We find out about Bitfo and what services they offer
+    We discuss Dave’s blog post on observability
+    Find out how Dave wrote the blog post because he saw a gap at his company
+    How Sundi proofread Dave’s blog post and realized her lack of knowledge on observability
+    The most common mistake teams or engineers make when it comes to observability
+    We peel back the layers on what telemetry is
+    What the difference between telemetry and OpenTelemetry is
+    How to choose which tool is right when it comes to better observability
+    *The breakdown of the uses for observability telemetry
+    *When and why would we use OpenTelemtry vs basic observability
+    *What languages Dave started in before he was working in Elixir
+    *How Elixir lends better for observability
+    *Where to start if you want to implement basic observability for someone who has no experience with it
+    *Dave answers the question, “can you go too far with observability?”
+    *We discuss Livebook and what exciting things it will bring for the future
+    *Most importantly, Dave explains why pineapples are important to him
+    **Links Mentioned in Today’s Episode:
+    Dave’s blog post on Observability: https://davelucia.com/blog/observing-elixir-with-lightstep
+    Dave Lucia on Twitter — https://twitter.com/davydog187
+    Dave Lucia on GitHub — https://github.com/davydog187
+    Dave Lucia on LinkedIn — https://www.linkedin.com/in/david-lucia-a395441b/
+    Bitfo — https://www.bitfo.com/
+    SmartLogic — https://smartlogic.io/
+  author: SmartLogic LLC
+  embedUrl: https://fireside.fm/player/v2/IAs5ixts+87YV43bE
+  enclosure:
+    url: https://aphid.fireside.fm/d/1437767933/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/ccdb0e5d-3009-44db-9573-d5a5a12696eb.mp3
+    length: '74289426'
+    type: audio/mpeg
+  itunes:
+    episodeType: full
+    season: '9'
+    author: SmartLogic LLC
+    subtitle: ''
+    duration: '51:35'
+    explicit: 'no'
+    keywords: bitfo, crypto, elixir, observability
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
+    summary: "\n        <p>Welcome to our first episode of Season 9 Elixir Wizards,
+      Parsing the Particulars. A show focused on conversations with software developers
+      from around the world on the Elixir language and other modern web technologies.
+      Today, we are joined by Dave Lucia, Chief Technology Officer at Bitfo, a cryptocurrency
+      media company building educational content for people who are interested in
+      cryptocurrency. Dave is active in the Elixir community and in the past has spoken
+      at Code BEAM SF, ElixirConf, RabbitMQ Summit, and has written several blog posts
+      which can be found at davelucia.com. In today’s episode we find out more about
+      Dave’s professional background and dive into the particulars of observability.
+      Tune in today to learn more from today’s special guest, Dave Lucia!</p>\n\n<p>Key
+      Points From This Episode:</p>\n\n<ul>\n<li>A brief breakdown of today’s topic
+      and introduction to our special guest, Dave Lucia</li>\n<li>We find out about
+      Bitfo and what services they offer</li>\n<li>We discuss Dave’s blog post on
+      observability</li>\n<li>Find out how Dave wrote the blog post because he saw
+      a gap at his company</li>\n<li>How Sundi proofread Dave’s blog post and realized
+      her lack of knowledge on observability</li>\n<li>The most common mistake teams
+      or engineers make when it comes to observability</li>\n<li>We peel back the
+      layers on what telemetry is</li>\n<li>What the difference between telemetry
+      and OpenTelemetry is</li>\n<li>How to choose which tool is right when it comes
+      to better observability\n*The breakdown of the uses for observability telemetry\n*When
+      and why would we use OpenTelemtry vs basic observability\n*What languages Dave
+      started in before he was working in Elixir\n*How Elixir lends better for observability\n*Where
+      to start if you want to implement basic observability for someone who has no
+      experience with it\n*Dave answers the question, “can you go too far with observability?”\n*We
+      discuss Livebook and what exciting things it will bring for the future\n*Most
+      importantly, Dave explains why pineapples are important to him</li>\n</ul>\n\n<p>**Links
+      Mentioned in Today’s Episode:</p>\n\n<ul>\n<li>Dave’s blog post on Observability:
+      <a href=\"https://davelucia.com/blog/observing-elixir-with-lightstep\" rel=\"nofollow\">https://davelucia.com/blog/observing-elixir-with-lightstep</a></li>\n<li>Dave
+      Lucia on Twitter — <a href=\"https://twitter.com/davydog187\" rel=\"nofollow\">https://twitter.com/davydog187</a></li>\n<li>Dave
+      Lucia on GitHub — <a href=\"https://github.com/davydog187\" rel=\"nofollow\">https://github.com/davydog187</a></li>\n<li>Dave
+      Lucia on LinkedIn — <a href=\"https://www.linkedin.com/in/david-lucia-a395441b/\"
+      rel=\"nofollow\">https://www.linkedin.com/in/david-lucia-a395441b/</a></li>\n<li>Bitfo
+      — <a href=\"https://www.bitfo.com/\" rel=\"nofollow\">https://www.bitfo.com/</a></li>\n<li>SmartLogic
+      — <a href=\"https://smartlogic.io/\" rel=\"nofollow\">https://smartlogic.io/</a></li>\n</ul><p>Links:</p><ul><li><a
+      href=\"https://open.spotify.com/episode/3RmFXCjuVIsT1DqzqSZgAv?si=1c5d7a3171164223\"
+      title=\"Spotify\" rel=\"nofollow\">Spotify</a></li></ul>\n      "
+  contentEncoded: "\n        <p>Welcome to our first episode of Season 9 Elixir Wizards,
+    Parsing the Particulars. A show focused on conversations with software developers
+    from around the world on the Elixir language and other modern web technologies.
+    Today, we are joined by Dave Lucia, Chief Technology Officer at Bitfo, a cryptocurrency
+    media company building educational content for people who are interested in cryptocurrency.
+    Dave is active in the Elixir community and in the past has spoken at Code BEAM
+    SF, ElixirConf, RabbitMQ Summit, and has written several blog posts which can
+    be found at davelucia.com. In today’s episode we find out more about Dave’s professional
+    background and dive into the particulars of observability. Tune in today to learn
+    more from today’s special guest, Dave Lucia!</p>\n\n<p>Key Points From This Episode:</p>\n\n<ul>\n<li>A
+    brief breakdown of today’s topic and introduction to our special guest, Dave Lucia</li>\n<li>We
+    find out about Bitfo and what services they offer</li>\n<li>We discuss Dave’s
+    blog post on observability</li>\n<li>Find out how Dave wrote the blog post because
+    he saw a gap at his company</li>\n<li>How Sundi proofread Dave’s blog post and
+    realized her lack of knowledge on observability</li>\n<li>The most common mistake
+    teams or engineers make when it comes to observability</li>\n<li>We peel back
+    the layers on what telemetry is</li>\n<li>What the difference between telemetry
+    and OpenTelemetry is</li>\n<li>How to choose which tool is right when it comes
+    to better observability\n*The breakdown of the uses for observability telemetry\n*When
+    and why would we use OpenTelemtry vs basic observability\n*What languages Dave
+    started in before he was working in Elixir\n*How Elixir lends better for observability\n*Where
+    to start if you want to implement basic observability for someone who has no experience
+    with it\n*Dave answers the question, “can you go too far with observability?”\n*We
+    discuss Livebook and what exciting things it will bring for the future\n*Most
+    importantly, Dave explains why pineapples are important to him</li>\n</ul>\n\n<p>**Links
+    Mentioned in Today’s Episode:</p>\n\n<ul>\n<li>Dave’s blog post on Observability:
+    <a href=\"https://davelucia.com/blog/observing-elixir-with-lightstep\" rel=\"nofollow\">https://davelucia.com/blog/observing-elixir-with-lightstep</a></li>\n<li>Dave
+    Lucia on Twitter — <a href=\"https://twitter.com/davydog187\" rel=\"nofollow\">https://twitter.com/davydog187</a></li>\n<li>Dave
+    Lucia on GitHub — <a href=\"https://github.com/davydog187\" rel=\"nofollow\">https://github.com/davydog187</a></li>\n<li>Dave
+    Lucia on LinkedIn — <a href=\"https://www.linkedin.com/in/david-lucia-a395441b/\"
+    rel=\"nofollow\">https://www.linkedin.com/in/david-lucia-a395441b/</a></li>\n<li>Bitfo
+    — <a href=\"https://www.bitfo.com/\" rel=\"nofollow\">https://www.bitfo.com/</a></li>\n<li>SmartLogic
+    — <a href=\"https://smartlogic.io/\" rel=\"nofollow\">https://smartlogic.io/</a></li>\n</ul><p>Links:</p><ul><li><a
+    href=\"https://open.spotify.com/episode/3RmFXCjuVIsT1DqzqSZgAv?si=1c5d7a3171164223\"
+    title=\"Spotify\" rel=\"nofollow\">Spotify</a></li></ul>\n      "
 - title: We're baaaack! Season 9 Teaser
   slug: teasers9
   link: https://smartlogic.io/podcast/elixir-wizards/teasers9
   guid: e16cbd56-185c-4abf-a193-52a629580bc7
   pubDate: Thu, 22 Sep 2022 00:00:00 -0400
   pubDateFriendly: September 22, 2022
-  description: ''
+  description: "Hey everyone, Season 9 of Elixir Wizards is back! This season's theme
+    is Parsing the Particulars, where we dive into particular subjects with our guests.
+    Your returning hosts this season are Sundi, Owen and Dan! And we are excited to
+    announce that we have a new host joining the show - Bilal Hankins! Bilal is a
+    Software Developer at SmartLogic and is super excited to join us this season.
+    \nSome of this season's guests include Dave Lucia, CTO at Bitfo, Tyler Young,
+    Senior Software Developer at Felt, and Kate Rezentes, Junior Developer at SimpleBet.
+    Can't wait to see you there!\nSmartLogic — https://smartlogic.io/ \nSmartLogic
+    on Twitter — https://twitter.com/smartlogic\nSmartLogic on LinkedIn — https://www.linkedin.com/company/smartlogic-io/\nSmartLogic
+    on Facebook — https://www.facebook.com/smartlogic/\nBilal Hankins on LinkedIn
+    — https://www.linkedin.com/in/hankins-bilal/\nSundi Myint on LinkedIn — https://www.linkedin.com/in/sundimyint/\nOwen
+    Bickford on LinkedIn — https://www.linkedin.com/in/owen-bickford-8b6b1523a/\n"
   author: SmartLogic LLC
   embedUrl: https://fireside.fm/player/v2/IAs5ixts+TDzrU9qw
   enclosure:
@@ -6177,9 +6491,42 @@ Season 9:
     duration: '1:07'
     explicit: 'no'
     keywords: 'elixir, tech, code '
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/e/e16cbd56-185c-4abf-a193-52a629580bc7/cover.jpg?v=1
-    summary: "\n        \n      "
-  contentEncoded: "\n        \n      "
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
+    summary: "\n        <p>Hey everyone, Season 9 of Elixir Wizards is back! This
+      season&#39;s theme is Parsing the Particulars, where we dive into particular
+      subjects with our guests. Your returning hosts this season are Sundi, Owen and
+      Dan! And we are excited to announce that we have a new host joining the show
+      - Bilal Hankins! Bilal is a Software Developer at SmartLogic and is super excited
+      to join us this season. </p>\n\n<p>Some of this season&#39;s guests include
+      Dave Lucia, CTO at Bitfo, Tyler Young, Senior Software Developer at Felt, and
+      Kate Rezentes, Junior Developer at SimpleBet. Can&#39;t wait to see you there!</p>\n\n<p>SmartLogic
+      — <a href=\"https://smartlogic.io/\" rel=\"nofollow\">https://smartlogic.io/</a>
+      <br>\nSmartLogic on Twitter — <a href=\"https://twitter.com/smartlogic\" rel=\"nofollow\">https://twitter.com/smartlogic</a><br>\nSmartLogic
+      on LinkedIn — <a href=\"https://www.linkedin.com/company/smartlogic-io/\" rel=\"nofollow\">https://www.linkedin.com/company/smartlogic-io/</a><br>\nSmartLogic
+      on Facebook — <a href=\"https://www.facebook.com/smartlogic/\" rel=\"nofollow\">https://www.facebook.com/smartlogic/</a><br>\nBilal
+      Hankins on LinkedIn — <a href=\"https://www.linkedin.com/in/hankins-bilal/\"
+      rel=\"nofollow\">https://www.linkedin.com/in/hankins-bilal/</a><br>\nSundi Myint
+      on LinkedIn — <a href=\"https://www.linkedin.com/in/sundimyint/\" rel=\"nofollow\">https://www.linkedin.com/in/sundimyint/</a><br>\nOwen
+      Bickford on LinkedIn — <a href=\"https://www.linkedin.com/in/owen-bickford-8b6b1523a/\"
+      rel=\"nofollow\">https://www.linkedin.com/in/owen-bickford-8b6b1523a/</a></p>\n
+      \     "
+  contentEncoded: "\n        <p>Hey everyone, Season 9 of Elixir Wizards is back!
+    This season&#39;s theme is Parsing the Particulars, where we dive into particular
+    subjects with our guests. Your returning hosts this season are Sundi, Owen and
+    Dan! And we are excited to announce that we have a new host joining the show -
+    Bilal Hankins! Bilal is a Software Developer at SmartLogic and is super excited
+    to join us this season. </p>\n\n<p>Some of this season&#39;s guests include Dave
+    Lucia, CTO at Bitfo, Tyler Young, Senior Software Developer at Felt, and Kate
+    Rezentes, Junior Developer at SimpleBet. Can&#39;t wait to see you there!</p>\n\n<p>SmartLogic
+    — <a href=\"https://smartlogic.io/\" rel=\"nofollow\">https://smartlogic.io/</a>
+    <br>\nSmartLogic on Twitter — <a href=\"https://twitter.com/smartlogic\" rel=\"nofollow\">https://twitter.com/smartlogic</a><br>\nSmartLogic
+    on LinkedIn — <a href=\"https://www.linkedin.com/company/smartlogic-io/\" rel=\"nofollow\">https://www.linkedin.com/company/smartlogic-io/</a><br>\nSmartLogic
+    on Facebook — <a href=\"https://www.facebook.com/smartlogic/\" rel=\"nofollow\">https://www.facebook.com/smartlogic/</a><br>\nBilal
+    Hankins on LinkedIn — <a href=\"https://www.linkedin.com/in/hankins-bilal/\" rel=\"nofollow\">https://www.linkedin.com/in/hankins-bilal/</a><br>\nSundi
+    Myint on LinkedIn — <a href=\"https://www.linkedin.com/in/sundimyint/\" rel=\"nofollow\">https://www.linkedin.com/in/sundimyint/</a><br>\nOwen
+    Bickford on LinkedIn — <a href=\"https://www.linkedin.com/in/owen-bickford-8b6b1523a/\"
+    rel=\"nofollow\">https://www.linkedin.com/in/owen-bickford-8b6b1523a/</a></p>\n
+    \     "
 Season 8:
 - title: Looking back on Season 8 with Sundi, Owen & Dan
   slug: s8e12-finale
@@ -6225,7 +6572,7 @@ Season 8:
     duration: '38:23'
     explicit: 'no'
     keywords: ''
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/2/2cd157b4-8fcd-4025-9d56-76a10fb61903/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>It’s the season finale show! Can you believe it? Join us
       this week as Sundi, Owen, and Dan take a look back at this season of Elixir
       Wizards! You’ll hear their discussion about favorite moments over the season
@@ -6312,7 +6659,7 @@ Season 8:
     duration: '29:11'
     explicit: 'no'
     keywords: ''
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/3/3d022fd3-b8f1-41da-97ac-8e9b5784bfa3/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>This week on Elixir Wizards we’re joined by Nathan Retta,
       Senior Software Engineer from Android at DoorDash. We learn about Nathan’s background;
       his experience having a degree in Chemical Engineering and working in Oil and
@@ -6364,7 +6711,7 @@ Season 8:
     duration: '44:41'
     explicit: 'no'
     keywords: ''
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/a/acc26d2b-07e6-4dad-8ef5-e78780d17650/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Welcome to this week’s episode of Elixir Wizards, with
       our special guest, Cara Mitchell of Pepsi Co. Today we speak with Cara about
       her career journey that led to her living in the lower East Side of New York
@@ -6441,7 +6788,7 @@ Season 8:
     duration: '42:48'
     explicit: 'no'
     keywords: ''
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/9/9114fce2-a423-4c1d-9ca6-c5ff2098dd34/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Joining us today on Elixir Wizards is Catalina Astengo,
       Staff Software Engineer at Nav Inc. We chat with Catalina about how she went
       from working as a process engineer in a mine to a software engineer in beautiful
@@ -6593,7 +6940,7 @@ Season 8:
     duration: '45:35'
     explicit: 'no'
     keywords: ''
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/7/7a1f4173-df13-4237-9d32-e862b6512a16/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Welcome to another episode of Elixir Wizards, a show focused
       on conversations with software developers from around the world on the Elixir
       language and other modern web technologies. In today’s episode, we speak with
@@ -6779,7 +7126,7 @@ Season 8:
     duration: '43:42'
     explicit: 'no'
     keywords: ''
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/9/942f6a18-066a-4996-b3f8-9b0712959574/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>A superpower of software development is teaching our code
       to teach us what’s happening. This is observability, and it’s why Jessica Kerr
       works at Honeycomb, where she is a Developer Advocate. After twenty years as
@@ -6955,7 +7302,7 @@ Season 8:
     duration: '42:58'
     explicit: 'no'
     keywords: ''
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/c/c1e61882-d69a-47d8-af8b-a1a1b3f33708/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Welcome back to another episode of Elixir Wizards. Today,
       we chat with Digit, a talented software engineer currently based at SmartRent.
       He became aware of the company when he started trying to modify his smart home
@@ -7101,7 +7448,7 @@ Season 8:
     duration: '45:20'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/2/23a28e9b-417e-4841-9b86-addd0247ce4e/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Joining us in conversation today is Nathan Willson all
       the way from Tokyo, Japan. Listeners will learn about the polyglot landscape
       he works in from Japan, why he believes knowing a language, and mastering it,
@@ -7235,7 +7582,7 @@ Season 8:
     duration: '43:31'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/3/32849026-ad26-4b84-9a89-316306f6e3c1/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>This week we are joined by Sanne Kalkman, former teacher
       turned software engineer. Currently, Sanne works at CodeSandbox, where she&#39;s
       one of two Elixir developers responsible for the backend. When she&#39;s not
@@ -7395,7 +7742,7 @@ Season 8:
     duration: '1:00:36'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/c/c1436a7a-59b9-402a-970c-f87791f275e1/cover.jpg?v=2
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>This double guest episode features Cassidy Williams, Head
       of Developer Experience and Education and Tobi Pfeiffer, Staff Engineer from
       Remote. This fast growing Elixir company provides HR support to clients who
@@ -7573,7 +7920,7 @@ Season 8:
     duration: '48:07'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/9/95a396ef-84bd-43e0-b0ae-dc8276917eb9/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Today’s guest is Devon Estes, who leads the third-party
       integration team at Remote, a company that uses technology to make it easier
       for other companies to hire remote employees (not contractors, actual employees)
@@ -7699,7 +8046,7 @@ Season 8:
     duration: '48:47'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/f/f4a94090-3527-4b5f-924e-beb55f9688c5/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Welcome to the new season of Elixir Wizards: Elixir in
       a Polyglot Environment. To get things going on this exciting and intriguing
       subject we are very happy to welcome Miguel Cobá! Miguel currently works at
@@ -7842,7 +8189,7 @@ Season 7:
     duration: '56:55'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/8/8ddde7c8-d4df-4b6b-88dd-7ac7796534c1/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Welcome to the Season 7 finale! Today, we are joined by
       Todd Resudek, Staff Engineer at Jackpocket, to reflect on the past season and
       speak about the impact of Elixir, as well as a variety of other topics almost
@@ -7993,7 +8340,7 @@ Season 7:
     duration: '45:33'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/d/d64b67ed-770e-44c1-8032-b2666cc84d48/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>This week we welcome Arthi Radhakrishnan back to the show
       to discuss how Elixir and her career more broadly have shaped her perspectives
       on learning. Arthi first got into programming as a child growing up in the Bay
@@ -8130,7 +8477,7 @@ Season 7:
     duration: '51:20'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/a/a9b73218-2d0c-4a6f-9bba-93d5c355db7a/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Today we welcome software engineer Meryl Dakin to the show,
       who is currently employed by Knock. Meryl is here to help us continue our exploration
       of this season&#39;s theme of the impact of Elixir, and we get to hear about
@@ -8297,7 +8644,7 @@ Season 7:
     duration: '46:05'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/6/66261581-0dd2-4380-8280-495736a41540/cover.jpg?v=2
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>We are very excited to welcome Brooklyn Zelenka back to
       the podcast to talk about her work at Fission and the ever-expanding frontier
       of edge computing! Brooklyn is a co-founder and CTO at Fission and she gives
@@ -8458,7 +8805,7 @@ Season 7:
     duration: '50:42'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/b/bb8d89d6-4176-4414-b0fe-8e569cff9408/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>We are always excited to have conversations about the growth
       of the Elixir community, and today we go truly global, welcoming Sigu Magwa
       to the podcast, who hails from Kenya! Sigu is currently traveling in the US
@@ -8614,7 +8961,7 @@ Season 7:
     duration: '56:10'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/c/c628b216-0cf4-431f-b430-377ad40bf4ff/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Brooklin Myers is on a quest to change the perception that
       Elixir is difficult to get into and we are so grateful to have him as a guest
       on the show today. Aside from being a passionate programmer, Brooklin spends
@@ -8764,7 +9111,7 @@ Season 7:
     duration: '45:17'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/0/03563586-ac91-4c9e-a6ec-f7a91318d2b7/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>It is important to us that the Elixir community keeps thriving,
       and one of the best ways to ensure this is by lowering the barrier to entry
       as much as possible. Livebook is helping to achieve this aim, and today we are
@@ -8938,7 +9285,7 @@ Season 7:
     duration: '42:11'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/4/496000a0-b38c-4ab6-96f8-a0948d8c6d40/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Today on the show we are grateful to get the chance to
       speak with Yiming Chen from Tubi, where we hear all about how he likes to use
       Elixir and the contributions he has made to the community. We begin as always
@@ -9102,7 +9449,7 @@ Season 7:
     duration: '47:53'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/5/5c3a89b0-b7f6-4b83-aebb-af04520dba3e/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Today we are joined by programmer, professor, educator,
       and podcaster, Adolfo Neto! We have a fascinating conversation that continues
       our exploration of the theme of the impact of Elixir, hearing from Adolfo about
@@ -9266,7 +9613,7 @@ Season 7:
     duration: '48:52'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/e/e7dec128-99fe-4b5f-9f1c-0844b6424558/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>As we continue this season of the podcast, focusing on
       the impact of Elixir, we are joined by Florian Kraft, all the way from Berlin,
       Germany! Florian works as a software engineer at Contentful, and has a number
@@ -9443,7 +9790,7 @@ Season 7:
     duration: '47:57'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/1/196446c8-44e8-4c34-86c8-a688bfb3f706/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Today’s guest is Angel Jose, a Software Engineer Manager
       at Cars.com with a passion for product and the customer experience. Angel played
       a key role in completely re-platforming Cars.com via Elixir, Phoenix, and other
@@ -9583,7 +9930,7 @@ Season 7:
     duration: '58:47'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/6/6610fc7c-e295-43f4-b542-40847c96f358/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>As we kick off our new, seventh season of the Elixir Wizards
       podcast, we wanted to introduce our theme of the impact of Elixir by having
       a simple chat between our panel and foregoing our usual guest format. As fans
@@ -9708,7 +10055,7 @@ Season 6:
     duration: '57:56'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/5/5bcca27a-dc98-4584-a152-84f4b04ee0d5/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>We have reached the final episode of our season, and as
       we wrap up our exploration of BEAM magic, we are joined by Amos King, whose
       tweet was the inspiration behind this season&#39;s focus! We&#39;ve had such
@@ -9855,7 +10202,7 @@ Season 6:
     duration: '38:30'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/3/332edbe7-b497-4b63-a474-8d468123d586/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>This episode serves as a round-up of some of the special
       mini-features we have recorded throughout Season 6, where we&#39;ll hear from
       Tyler Clemens, Elom Amouzou, Elise Navarro, and Jeremy Neal about their work
@@ -10030,7 +10377,7 @@ Season 6:
     duration: '44:54'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/1/1487b980-5611-4fbc-9c58-7b4508ebefa9/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Joining us on the show today is Quinn Wilton, and we have
       a wonderful conversation with our guest about her journey with Elixir, unusual
       path into programming, and her wide appreciation for different languages! We
@@ -10183,7 +10530,7 @@ Season 6:
     duration: '46:34'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/5/5e1ccc21-8727-4ae4-8921-ae296f46cff7/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>While NIFs provide a great way to interface with native
       code in the BEAM machine, the process can also be rather error-prone. Thankfully,
       since Isaac Yonemoto built Zigler, things have become a lot simpler, and he
@@ -10339,7 +10686,7 @@ Season 6:
     duration: '50:13'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/f/ff944923-7612-4245-b9b0-d9217e878b0b/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Today we are so excited to share a conversation with Maxim
       Fedorov, who is the Core Infrastructure Lead at communications giant, WhatsApp!
       In our chat, Maxim offers such interesting insight and wisdom from a long career
@@ -10509,7 +10856,7 @@ Season 6:
     duration: '48:08'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/4/49a8c965-5f19-4aba-9cd7-6b59acc7188b/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Some of you may recognize Chelsea Troy from her popular
       blog of the same name or as a keynote speaker for the March 2021 Code BEAM conference.
       Chelsea is an instructor in the Master&#39;s Program in Computer Science at
@@ -10685,7 +11032,7 @@ Season 6:
     duration: '56:18'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/3/3cc0b619-ef6a-48ed-a0d6-8566f26ed0a9/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>While we can think of many reasons why we love Elixir,
       the community could always benefit from a more lively conversation around testing.
       It was with this in mind that Jeffrey Matthias and Andrea Leopardi decided to
@@ -10876,7 +11223,7 @@ Season 6:
     duration: '46:33'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/3/3c07dbc2-eadc-48b9-9136-7decec7a0f57/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Joining us for this episode of Elixir Wizards is the vastly
       experienced and well-traveled Francesco Cesarini! Francesco is the founder of
       Erlang Solutions and we are so lucky to have him here on the show to talk about
@@ -11089,7 +11436,7 @@ Season 6:
     duration: '54:11'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/9/95a7bb65-24d3-4155-bd40-9a4b4a94fbbb/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Today we have some extra BEAM magic for all of you! Joining
       us on the show is Chris Miller, who currently works as an Associate Software
       Engineer at Corvus Insurance. We get into a great conversation with Chris about
@@ -11280,7 +11627,7 @@ Season 6:
     duration: '50:21'
     explicit: 'no'
     keywords: ''
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/9/943755c0-4bf5-4c89-949c-44406ea58584/cover.jpg?v=3
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>While there is magic to be found in many frameworks, having
       too much going on under the hood without you being able to control it is not
       for everybody. Today we invite Parker and Shannon Selbert to speak about their
@@ -11462,7 +11809,7 @@ Season 6:
     duration: '1:00:41'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/f/f1486983-1421-45be-87ae-99a0a56ec848/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Today we are joined by the Vice President of Engineering
       at Corvus Insurance, Erik Person! Erik continues our journey into the magic
       of the BEAM, our season-long theme for the Elixir Wizards Podcast, and we get
@@ -11666,7 +12013,7 @@ Season 6:
     duration: '49:38'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/1/10914181-66e0-4200-b6c8-260bee7e32bd/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Welcome to a brand-spanking-new season of Elixir Wizards!
       This time around we will be focussing on the magic of the BEAM, so get ready
       for an exciting journey into new territories filled with mystery and power!
@@ -11868,7 +12215,7 @@ Season 5:
     duration: '1:01:39'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/1/12f603e4-7d53-4e83-baed-33e436cbf102/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Season 5 ends with a bang as we welcome back Sean Lewis,
       Anna Neyzber, and René Föhring onto the show to share their journey on getting
       their companies and teams to adopt Elixir. We open our conversation with each
@@ -12054,7 +12401,7 @@ Season 5:
     duration: '47:38'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/2/2bb38486-078c-44b5-a40c-b2c71a50d210/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>The fields of data science and machine learning are moving
       ever faster. Jenn Gamble has her finger on the pulse and has become an industry
       expert with a wealth of experience to her name. As today’s guest, she dives
@@ -12222,7 +12569,7 @@ Season 5:
     duration: '43:27'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/d/d761c5dd-b1bf-4062-a4e0-fe20d7c85e7f/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Many organizations take an incremental approach when adopting
       Elixir, preferring to pick up its nuances by using it to work on non-essential
       projects. But not Change.org. Today we speak with Change.org Director of Engineering
@@ -12409,7 +12756,7 @@ Season 5:
     duration: '48:20'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/9/9470edd5-3447-4d40-9f5d-aaba34126ae3/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>As users increasingly demand interactivity from their web
       experiences, Phoenix LiveView is becoming the dominant way of writing interactive
       Elixir applications without a loss to reliability. Today we welcome back an
@@ -12617,7 +12964,7 @@ Season 5:
     duration: '50:45'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/9/97fc73f8-1e61-447f-953f-99d2580f1476/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>With the prevalence of at-home learning, teachers have
       to compete for student attention against numerous screen-based activities. Today
       we speak with engineering lead Shaun Robinson and Elixir developer Toran Billups
@@ -12829,7 +13176,7 @@ Season 5:
     duration: '59:23'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/1/1b9ca1de-dc95-49fa-885b-4e6093d52055/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>ClusterTruck, a master of vertical integration, is rewriting
       the method of end-to-end food delivery and ghost kitchens. Today we speak with
       ClusterTruck Product VP Brian Howenstein to find out more about his journey
@@ -13036,7 +13383,7 @@ Season 5:
     duration: '55:46'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/b/bc908c5d-f422-4fc4-809b-ec4f4b051d3a/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Building a successful development company requires having
       a leader with technical know-how and excellent management skills. Today we speak
       with SmartLogic President and Founder Yair Flicker about his company’s origin
@@ -13200,7 +13547,7 @@ Season 5:
     duration: '48:25'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/d/d3843a34-8180-4e29-ae31-ab4d2da8379b/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Despite its welcoming character, the Elixir community struggles
       with diversity; as the 2020 ElixirConf community survey shows, only 2% of Elixirists
       are women. Today we speak with Blinker software engineer Alexandra Chakeres
@@ -13371,7 +13718,7 @@ Season 5:
     duration: '53:12'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/1/1752ae0e-feb0-4606-b3b0-97f70e29e3de/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>In this episode we continue our conversation about adopting
       Elixir, this time with Matt Nowack and Jake Heinz from Discord, hearing them
       get into the features of Elixir that make it a great fit for building a real-time
@@ -13550,7 +13897,7 @@ Season 5:
     duration: '33:57'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/6/6475cfad-49d7-498d-a06a-c9af4a82e710/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Welcome back to the Elixir Wizards podcast! In this episode,
       we will be continuing our conversation on the theme of adopting elixir, and
       our great guest for today is Jason Axelson! Jason is a back-end developer for
@@ -13729,7 +14076,7 @@ Season 5:
     duration: '38:33'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/6/6d2c98f6-1ba5-4003-8e4a-d98265dccd91/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Anyone who has written software for the travel industry
       can tell you that it is in desperate need of innovation — shockingly many of
       their cobwebbed systems were built in the 70s. Today we speak with Duffel CEO
@@ -13900,7 +14247,7 @@ Season 5:
     duration: '38:57'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/a/a15c1f14-3ae4-4a02-a642-a03ab3e11660/cover.jpg?v=2
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>To beat out their competitors, startups need to code quickly,
       simply, and in a language that attracts top engineers. Enter Elixir. Today we
       speak with Shawn Vo, Axle Payments Co-Founder and CTO, about his journey with
@@ -14092,7 +14439,7 @@ Season 5:
     duration: '47:20'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/6/6e5cd223-dc2c-42ee-9c40-d7e778b4ee9b/cover.jpg?v=2
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Today we sit down with Erlanger Viktória Fördős, who talks
       with us about Erlang and how it is used at Cisco. We open the show by finding
       out about Viki’s background in coding and her unorthodox entry into the field.
@@ -14297,7 +14644,7 @@ Season 5:
     duration: '37:27'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/4/4653eb7c-8637-447c-8ead-a6fe53e5c3cc/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Today’s guest is Simon Glenn-Gregg, News Engineer at The
       Washington Post. He joins us to talk about using Elixir to build a prototype
       for a platform the news house recently implemented to visualize the results
@@ -14511,7 +14858,7 @@ Season 5:
     duration: '53:09'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/4/41c6ea5d-4915-4a6e-9795-3e2a9b57aa72/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>The culture of your programming community directly impacts
       your professional success. As Thunderbolt Labs Founder Randall Thomas explains
       in this episode, a community that practices openness and which warmly welcomes
@@ -14731,7 +15078,7 @@ Season 5:
     duration: '56:34'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/4/4a9a2637-46ff-42d5-af60-6c46bbf9c3fa/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Welcome back to Elixir Wizards, season five, episode one!
       The theme for this season is ‘Adopting Elixir’, and for today’s show the team
       at Elixir Outlaws play host! Chris Keathley, Amos King, and Anna Neyzberg give
@@ -14921,7 +15268,7 @@ Season 4:
     duration: '59:12'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/8/8cbeff8e-7468-4da6-a117-7e0a1f94d653/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>To close off this season and conclude our deep dive into
       system and application architecture, today’s episode is a special panel discussion
       on a topic that has provoked a mix of answers that range from the controversial
@@ -15130,7 +15477,7 @@ Season 4:
     duration: '35:16'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/6/6cb1796f-017c-4f06-bd10-9cbf85fff404/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Even with the most programming experience in the world,
       coding still involves a lot of trial and error. People getting started in the
       industry should not become bogged down by failure. Because in the end, it’s
@@ -15313,7 +15660,7 @@ Season 4:
     duration: '48:36'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/b/b59ac59d-736e-4581-b0c0-e04adeb1ba91/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>There is no difference between architecture and design.
       It&#39;s all engineering and creating a distinction between the two is a way
       for someone to get paid more and have a different title. That hot take comes
@@ -15510,7 +15857,7 @@ Season 4:
     duration: '48:24'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/a/a61dcf3a-a8e5-45c7-a648-6994628ce9ec/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Imagine being hired into a rocketship startup using Elixir
       as its primary language. And all this, straight out of college. Today, we speak
       with systems software engineer, Lizzie Paquette who works at Brex, the aforementioned
@@ -15767,7 +16114,7 @@ Season 4:
     duration: '49:09'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/7/7070efa5-519a-4d9b-ac5a-75cfc1882a31/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Building a sophisticated AI that can evolve to fit our
       vast and diverse needs is a Herculean challenge. Today we speak with senior
       engineer Eric Steen about Automata, his experimental Elixir project that uses
@@ -16027,7 +16374,7 @@ Season 4:
     duration: '42:29'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/4/441f7029-d8ab-4494-aa7b-cfb08e4ade23/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>According to an ancient myth, the world rests on the back
       of a turtle. And what does that turtle stand on? Another turtle. It turns out
       that it’s turtles all the way down. Miki Rezentes, today’s guest, believes that
@@ -16318,7 +16665,7 @@ Season 4:
     duration: '1:17:12'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/a/a233d61f-e572-4479-a477-18b0d08fb053/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>With ElixirConf 2020 just around the corner, today’s episode
       is a sneak peek where we talk with six of this year’s speakers. Each speaker
       gives listeners an elevator pitch of their talk while throwing in extra details
@@ -16698,7 +17045,7 @@ Season 4:
     duration: '58:51'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/e/e18fef05-5ebe-42a1-9317-b193dfa84cd2/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Domain-driven design and extreme programming can help bridge
       the gap between development and business, and today we invite Mark Windholtz
       from Agile DNA to talk about how! Mark starts out by telling us about his early
@@ -16938,7 +17285,7 @@ Season 4:
     duration: '42:41'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/6/6cf32d50-909b-4839-a690-0fdc8ec48a2f/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Welcome to the second part of our special Elixir Wizards
       Dojo. A mashup made in partnership with ElixirConf Japan. In today’s episode,
       we talk to Nerves core team members Todd Resudek and Connor Rigby about all
@@ -17207,7 +17554,7 @@ Season 4:
     duration: '54:17'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/9/96d50b65-bc90-434e-ae8b-96b7c9f3990d/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Welcome to the first part of our extra special Elixir Wizards
       Dojo. A mashup made in partnership with ElixirConf Japan, in today’s episode,
       we pose questions asked by the Japanese Nerves community to Nerves core team
@@ -17440,7 +17787,7 @@ Season 4:
     duration: '41:43'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/f/f66990d4-1466-41eb-aa79-c89d644f8d94/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>In today’s episode, we chat about system architecture,
       Ruby, Elixir, and everything in between with Greg Mefford, the senior back-end
       engineer for the Bleacher Report. We open the conversation by asking Greg about
@@ -17676,7 +18023,7 @@ Season 4:
     duration: '49:14'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/1/1b6e0936-69df-48a0-83aa-42c3302bcb0a/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Johanna Larsson is a community-minded software engineer
       whose project, Hex Diff, generates highlighted git diffs, right in your browser.
       In this episode, we talk to Johanna about how Hex Diff can benefit Elixir users,
@@ -17901,7 +18248,7 @@ Season 4:
     duration: '37:32'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/f/f39e6147-f6c0-4c1e-803f-d128bfbec255/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Handling date and time is a challenge in any language,
       but Lau Taarnskov is determined to solve that problem in Elixir. Lau is today’s
       guest on Elixir Wizards, and this episode is all about his contributions to
@@ -18087,7 +18434,7 @@ Season 4:
     duration: '55:09'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/e/e9769249-24cb-455c-9983-011f1c414d3d/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>For part 2 of our Council of Wizards panel discussion,
       we are joined by Chris Bell, Desmond Bowe, Emily Maxie, Dan Lindeman, and Alan
       Voss! Chris and Desmond run the ElixirTalk Podcast and we get in-depth on the
@@ -18274,7 +18621,7 @@ Season 4:
     duration: '39:28'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/2/2e71b35e-54cc-4bfe-be34-6567c5fb448c/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>The Elixir community continues to flourish and evolve in
       these uncertain times and in honor of this we have put together a live show
       with a number of special guests! In part one today, we are joined by Andrea
@@ -18447,7 +18794,7 @@ Season 4:
     duration: '43:42'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/c/c87149f2-e430-4fcb-8e22-e3242c625e1b/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Although it’s taken him four seasons to make an appearance,
       we are so glad to finally welcome Chris McCord, creator of the Phoenix framework,
       onto the show. While this season’s focus is on system and application architecture,
@@ -18631,7 +18978,7 @@ Season 4:
     duration: '55:23'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/c/c4183a48-6039-4dc1-b54b-c43973086490/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Today’s guest is Amos King, Principal CEO at Binary Noggin,
       and host on the Elixir Outlaws and This Agile Life podcasts. This episode is
       centered around a casual conversation about everything from programming, the
@@ -18803,7 +19150,7 @@ Season 4:
     duration: '45:58'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/f/f14188bd-903b-49eb-bc8b-f52429966e63/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Welcome to another episode of Elixir Wizards as we continue
       our journey into system and application architecture! Our featured guest today
       is Sundi Myint and she is here to share her journey with Elixir and her non-traditional
@@ -19019,7 +19366,7 @@ Season 4:
     duration: '1:09:43'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/9/9f7ee6f5-a587-4f63-9fc5-ec4cdca6676f/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Dave Thomas is recognized internationally as an expert
       who develops high-quality software–accurate and highly flexible systems. He
       helped write the now-famous Agile Manifesto, and regularly gives inspiring and
@@ -19212,7 +19559,7 @@ Season 4:
     duration: '38:27'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/e/e711fb4d-502b-4733-b5e2-01ff002b836a/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Joining us on the show for this episode is Ben Marx, author
       of Adopting Elixir and Principal Control Plane Engineer at the recently launched
       SubSpace! We continue our Season 4 journey into system and application architecture
@@ -19347,7 +19694,7 @@ Season 4:
     duration: '14:46'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/a/ac3f0d31-f498-4d6a-ba69-3dbae9d0510f/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>A special episode of Elixir Wizards highlighting Pattern
       Matching with Todd - a short format interview where our friend, Todd Resudek,
       asks different guests the same five questions. This week Todd spoke with Johanna
@@ -19432,7 +19779,7 @@ Season 4:
     duration: '49:26'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/b/b07768d6-b987-496e-87d3-483eedd42fa5/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Real-time applications come with real challenges—persistent
       connections, multi-server deployment, and strict performance requirements are
       just a few. Our guest today is Steve Bussey, a software architect at SalesLoft
@@ -19572,7 +19919,7 @@ Season 4:
     duration: '43:22'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/a/a3a16821-cb7c-4c88-be0e-c2b412ad7bee/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Today’s guest is Mohd Maqbool Alam, a software developer
       and Elixir fan from Delhi. He enjoys learning about programming language theory,
       distributed systems, Cloud Native technologies, and open source. As he is working
@@ -19749,7 +20096,7 @@ Season 4:
     duration: '1:09:36'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/3/34c3c1af-3f50-4e83-be65-e7420d65eada/cover.jpg?v=2
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>As our first trilogy comes to a close, and we embark on
       the next one, we’re doing what all great trilogies do: Upending everything that
       made the initial one great and starting afresh. We have taken on board some
@@ -19991,7 +20338,7 @@ Season 4:
     duration: '53:26'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/d/dbe34c01-2361-41a8-ab85-dab81699cc7e/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>Welcome back to part two of our betweenisode! Everybody
       is working remotely now including ourselves, so today we continue the catch
       ups we were having with a number of longstanding buddies and chat about life
@@ -20250,7 +20597,7 @@ Season 4:
     duration: '53:16'
     explicit: 'no'
     keywords: elixir, phoenix
-    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/episodes/1/1b54b0cf-efaa-46fa-90b5-e40411069750/cover.jpg?v=1
+    image: https://assets.fireside.fm/file/fireside-images/podcasts/images/0/03a50f66-dc5e-4da4-ab6e-31895b6d4c9e/cover.jpg
     summary: "\n        <p>The world has changed so much since the end of season 3,
       that we thought we’d put together a special Betweenisode to tide you over until
       Season 4 launches. In this episode, we talk to several friends and respected

--- a/_data/elixir_wizards_transcripts.yml
+++ b/_data/elixir_wizards_transcripts.yml
@@ -187,3 +187,9 @@ s8e11-retta:
   English: "/podcast/elixir-wizards/transcripts/s8e11-retta.txt"
 s8e12-finale:
   English: "/podcast/elixir-wizards/transcripts/s8e12-finale.txt"
+s9e3-tyleryoung-felt:
+  English: "/podcast/elixir-wizards/transcripts/s9e3-tyleryoung-felt.txt"
+s9e2-kate-rezentes-simplebet:
+  English: "/podcast/elixir-wizards/transcripts/s9e2-kate-rezentes-simplebet.txt"
+s9e1-dave-lucia-bitfo:
+  English: "/podcast/elixir-wizards/transcripts/s9e1-dave-lucia-bitfo.txt"

--- a/_scripts/podcasts.rb
+++ b/_scripts/podcasts.rb
@@ -17,6 +17,8 @@ end
 
 rss_xml = Nokogiri::XML(response.body)
 
+fallback_image = rss_xml.xpath("//channel/itunes:image").first.attributes["href"].value
+
 items = rss_xml.xpath("//channel/item").map do |item|
   {
     "title" => item.xpath("title").text,
@@ -41,7 +43,7 @@ items = rss_xml.xpath("//channel/item").map do |item|
       "duration" => item.xpath("itunes:duration").text,
       "explicit" => item.xpath("itunes:explicit").text,
       "keywords" => item.xpath("itunes:keywords").text,
-      "image" => item.xpath("itunes:image").first.attributes["href"].value,
+      "image" => (item.xpath("itunes:image").first.attributes["href"].value rescue fallback_image),
       "summary" => item.xpath("itunes:summary").text,
     },
     "contentEncoded" => item.xpath("content:encoded").text

--- a/podcast/elixir-wizards/index.html
+++ b/podcast/elixir-wizards/index.html
@@ -46,15 +46,35 @@ include_rss: true
         <!-- transcript note -->
         <p><em><strong>Note:</strong> Our transcript writers aren't technical experts — if you see any errors in the show transcripts, you can <a target="_blank" href="https://github.com/smartlogic/smartlogic.io/tree/main/podcast/elixir-wizards/transcripts">submit a pull request</a> and we'll happily make the updates!</em></p>
 
-        <p><strong>Jump to a season:</strong> <a href=#s1>Season One: Elixir in Production</a> | <a href=#s2>Season Two: Elixir Internals</a> | <a href=#s3>Season Three: Working with Elixir</a> | <a href=#s4>Season Four: Application and System Architecture</a> | <a href=#s5>Season Five: Adopting Elixir</a> | <a href=#s6>Season Six: BEAM Magic</a></p>
+        <p>
+          <strong>Jump to a season:</strong>
+          <a href=#s1>Season One: Elixir in Production</a> | <a href=#s2>Season Two: Elixir Internals</a> |
+          <a href=#s3>Season Three: Working with Elixir</a> |
+          <a href=#s4>Season Four: Application and System Architecture</a> |
+          <a href=#s5>Season Five: Adopting Elixir</a> |
+          <a href=#s6>Season Six: BEAM Magic</a> |
+          <a href=#s7>Season Seven: The Impact of Elixir</a> |
+          <a href=#s8>Season Eight: Elixir in a Polyglot Environment</a> |
+          <a href=#s9>Season Nine: Parsing the Particulars</a>
+        </p>
     </section>
+    <!-- season nine -->
+
+    <section class="section content-block podcast" id="s9">
+        <h2>Season Nine: Parsing the Particulars</h2>
+        <p>Our theme in Season Nine is Parsing the Particulars. We'll be digging into the details about a specific topic of interest to our guests.</p>
+
+        <p>Season Nine began airing in September 2022.</p>
+      {% include season-episodes.html season='Season 9' %}
+    </section>
+
     <!-- season eight -->
 
     <section class="section content-block podcast" id="s8">
         <h2>Season Eight: Elixir in a Polyglot Environment</h2>
         <p>Our theme in Season Eight is Elixir in a Polyglot Environment. We'll be talking with our guests about how Elixir is used in context with other languages, how they play nicely (or not) together, and how teams manage context switching, constrain complexity, and generally think about how Elixir works within their overal product infrastructure.</p>
 
-        <p>Season Eight will begin airing in April 2022.</p>
+        <p>Season Eight aired from April 2022 through June 2022.</p>
       {% include season-episodes.html season='Season 8' %}
     </section>
 

--- a/podcast/elixir-wizards/transcripts/s9e1-dave-lucia-bitfo.txt
+++ b/podcast/elixir-wizards/transcripts/s9e1-dave-lucia-bitfo.txt
@@ -1,0 +1,810 @@
+﻿Sundi Myint:
+Welcome to Elixir Wizards, a podcast brought to you by SmartLogic, a custom web and mobile development shop based in Baltimore. My name is Sundi Myint, and I'll be your host and I'm joined by my co-host Owen Bickford. This season's theme is parsing the particulars. Today we are joined by special guest David Lucia from Bitfo, and we'll be diving into the particulars of observability. Hey Dave.
+
+
+David Lucia:
+Hello guys. Nice to see you.
+
+
+Sundi Myint:
+Nice to see you.
+
+
+Owen Bickford:
+Hey, Hey.
+
+
+Sundi Myint:
+Owen, how are you doing?
+
+
+Owen Bickford:
+I am cooking and moving and...
+
+
+Sundi Myint:
+Well, you're not literally cooking right now.
+
+
+Owen Bickford:
+Well, cooking figuratively. Yes. And literally moving in the near future. So yes.
+
+
+Sundi Myint:
+Yes.
+
+
+David Lucia:
+If you were moving, literally cooking, what would you be cooking right now Owen?
+
+
+Owen Bickford:
+Well, I'm out of leftovers actually Sundi and I have been talking about noodles. We're trying to be good, healthy people. And we're comparing notes on noodle options. So I'm in the chickpea noodle camp and Sundi you were sharing some other kind of noodles, what were those?
+
+
+Sundi Myint:
+Yeah. So miracle noodles are what the Western style has branded it, but the original name of it is a shirataki noodle. And it's like a noodle that's super low carb, but is made from a sweet yam, but it's like 97% water and like 3% of that flour. Yes, Dave, Dave's so excited about this.
+
+
+David Lucia:
+My wife is literally making shirataki noodles with green curry tonight. So I'm so excited. I was trying to Google to find the name because I was like, I don't remember the name, but this is relevant.
+
+
+Sundi Myint:
+Well, Owen, with that mind reading situation here again, this is...
+
+
+Owen Bickford:
+Go buy some lottery tickets real fast.
+
+
+Sundi Myint:
+This is really fun. So Dave, can you tell us what is new with you and your share talking? No. What is new with you, you're at Bitfo now, can you give us a little bit about that and then what's new with your life?
+
+
+David Lucia:
+Sure, absolutely. I don't know where to start, but I work at a company called Bitfo. We are a cryptocurrency media company and I joined as CTO there like four or five months ago, back in April. So busy writing a lot of Elixir and a bit of JavaScript too.
+
+
+Sundi Myint:
+Oh no, we don't say that word here Dave.
+
+
+David Lucia:
+I was going to say unfortunately, but maybe unfortunately. Yeah. So we've got a team over there of a few engineers, designers and editors, and we're building educational content for people who are interested in cryptocurrency.
+
+
+Sundi Myint:
+Educational content, you say, maybe something like what we're doing today?
+
+
+David Lucia:
+Could be.
+
+
+Sundi Myint:
+Not crypto related, but we are teaching folks. So since this is our season premiere, just like as a primer, we thought it'd be really cool to just dive in with experts on certain subjects, but not only experts, but also people who are interested in learning a thing. Maybe we can bring on an expert. If you are interested in coming onto Elixir Wizards, please let us know. Just reach out to us on Twitter, I believe, but we also have a discord, but we just want to learn. I think we were just super excited. Elixir conf, we just all got back from Elixir conf from using air quotes because Dave was not there.
+
+
+Owen Bickford:
+Poor Dave.
+
+
+David Lucia:
+Taunting me.
+
+
+Sundi Myint:
+Taunting you. I didn't send you too many pictures. I did really play that up. I would be sending you pictures the whole time. But...
+
+
+David Lucia:
+What you did do is you did send me pictures of all of the food that I wasn't having. It looked amazing.
+
+
+Sundi Myint:
+That is true. Really, this is true to my core of my personality. I'm a troll and I like to cook. It really gets combined in one very particular area.
+
+
+David Lucia:
+Owen, does Sundi, does she taunt you during the work day? How does this work?
+
+
+Owen Bickford:
+Our long running dispute is our puns dad jokes. I contend that puns are a different class of humor from dad jokes. And if you were at Elixir conf, sorry Dave, there was an entire comedy hour of dad jokes and Sundi, those were, I think we hopefully you'll agree that those were a different level from those...
+
+
+Sundi Myint:
+Those were dad jokes. Those were dad jokes.
+
+
+Owen Bickford:
+Those were coming from dads.
+
+
+Sundi Myint:
+I know what a dad joke is. Those were coming from dad's, dad jokes. For those who were not at Elixir conf, we had some technical difficulties at the beginning of Chris McCord's talk and they were roughly 30 minutes and everyone was gracious. Chris was gracious. The tech team was gracious. Thank you to that tech team. But the audience was also gracious in giving up their best and worst dad jokes for 30 minutes,
+
+
+Owen Bickford:
+Mostly worst, not a lot of keepers in that group of dad jokes. Just entertaining...
+
+
+David Lucia:
+I should mention with all the dad jokes that I am a dad. Since the last time we spoke, I had a baby son also named Owen excellent name, actually.
+
+
+Owen Bickford:
+Congratulations.
+
+
+David Lucia:
+Named after...
+
+
+Sundi Myint:
+Named after...
+
+
+David Lucia:
+Owen from Elixir Wizards of Oz.
+
+
+Owen Bickford:
+Because you met me weeks after.
+
+
+David Lucia:
+Yes. Yes. We waited for weeks and then finally it all made sense. And here we are.
+
+
+Owen Bickford:
+Well, congratulations.
+
+
+David Lucia:
+That's my big update.
+
+
+Sundi Myint:
+Yes. That is a humongous update. Congratulations.
+
+
+David Lucia:
+Thank you very much.
+
+
+Sundi Myint:
+And you also have two floof balls. That's what I call them. I know they are...
+
+
+David Lucia:
+They are Pomeranians. This is Pearl over here.
+
+
+Sundi Myint:
+But they're also technical term floof balls.
+
+
+David Lucia:
+Technically. Yeah. Scientifically. Yes.
+
+
+Sundi Myint:
+Okay, cool. So we're caught up there. And so if we want to dive into just kind of like this technical, oh my gosh. Oh my gosh. One of the floof balls is on screen.
+
+
+David Lucia:
+This is Pearl.
+
+
+Owen Bickford:
+Hey Pearl.
+
+
+David Lucia:
+She's six years old. She's going to live forever.
+
+
+Sundi Myint:
+Pearl, can you...
+
+
+Owen Bickford:
+She have any thoughts on observability?
+
+
+Sundi Myint:
+Yeah, I really want to ask her some observability questions. Did you observe any peanut butter today?
+
+
+David Lucia:
+She loves observing the mailman and the Amazon driver and anyone who walks by and I get an alert anytime they come by. So it's great observability.
+
+
+Sundi Myint:
+Amazing.
+
+
+Owen Bickford:
+So before we dive into the details, this is our first episode of season nine. So we're taking different topics for each episode and we're digging into details and talking to experts and wizards and different domains usually related to Elixir. So today we're talking about observability.
+
+
+Sundi Myint:
+And Dave, why are we talking about observability? This is a fun story.
+
+
+David Lucia:
+Why are we talking about observability? I wrote a blog post and I think a couple people read it, I'm not sure.
+
+
+Sundi Myint:
+It was going around the Twitter verse. A few retweets.
+
+
+David Lucia:
+So few retweets, but yeah, no, I wrote about observability specifically in Elixir and Erlang using honeycomb and LightStep. And I wrote it primarily because I saw a gap when I started at my new company Bitfo and wanted to get started and I'm like, wow, this is still kind of really hard. And I wish that someone else wrote up a guide and I'm like, maybe I should do that. So I spent an afternoon with something together and then I got some feedback from the community and published it. And I think it really struck a nerve for a lot of people who wanted to use some of the tools that are available, but we're still a little bit early on documentation and tutorials and guides and just could be a lot easier than it is right now. So I wrote about it.
+
+
+Owen Bickford:
+We'll make sure we have a link to the article and our show notes as well.
+
+
+Sundi Myint:
+Yes, absolutely. And when Dave was typing it up, he asked me to proofread it. And it was in that moment where I realized I knew nothing about observability or how to use it, or even what the word really meant. But I was like, I can review this from a beginner's point of view. And Dave's the part that you don't know is that you are more or less the inspiration for this season because I was like, that was fun. I should do that more often.
+
+
+David Lucia:
+So nice.
+
+
+Sundi Myint:
+This is a really great opportunity for me to learn more selfishly, Owen to learn more and teach more, because we'll be teaching some this season as well. Stay tuned for that. So to get right into it, what is the most common mistake you see teams or engineers make when it comes to observability?
+
+
+David Lucia:
+Very good question. So I think that people maybe are still new to the idea of what observability is and maybe that's the beginning of "the problem". So one, what is observability? Observability is a way, or it's more of a philosophy. It's like I have software, probably it runs on a server somewhere in the Cloud and if something's going wrong or if everything starts taking a really long time to serve requests. You want to figure out what is going wrong with this thing so I could fix it and get back to whatever you're doing. So the practice of observability is to add information outputs of your system so that you could see into it while it's running. So coming back to your question around what are mistakes that people make. I think it's not really having all of the right types of information coming out of your system. Telemetry, if you will.
+
+
+Sundi Myint:
+And can you define telemetry for those who don't know what that is?
+
+
+David Lucia:
+Yeah. So telemetry, I think comes from aviation could be wrong about that. Don't quote me on it, but...
+
+
+Sundi Myint:
+We won't post this anywhere.
+
+
+David Lucia:
+Someone can fact check me. Okay. I think it's from aviation might not be from aviation, but it's the idea of, okay, if you're flying a plane, you want to know what the altitude is. You want to know how much fuel you have left. You want to know what's the pitch and yaw of the plane and all those types of things. So you're getting this data out of your system. That's describing what the system is doing and how it's performing internally. So that extrapolates exactly to software where you have probably in your case, if you're listening to this, an Elixir program, that's running somewhere and you want to know things like how much memory is it being used? What's the available memory? What's the current utilization of the CPU. How many CPUs do I have? All of these things are telemetry data, but there's different types of telemetry right now. We're talking actually specifically about one type of telemetry called metrics.
+
+
+Sundi Myint:
+You look so excited about this. You did a little dance when you said metrics.
+
+
+David Lucia:
+I'm excited, because I'm like, well there's many, there's the three pillars, but there's actually not. That's something, that's an idea that tried to be pushed away, but okay. Let's just get into the other types of telemetry. So man, there's so many layers here to unpeel.
+
+
+Sundi Myint:
+All right. We are here to unpeel them.
+
+
+David Lucia:
+I'm not sure where to start.
+
+
+Sundi Myint:
+We've got it.
+
+
+David Lucia:
+Let's unpeel. Okay. So telemetry is a general concept. Use the example of aviation, but telemetry is just data that comes out of your system that describes the system itself. Metadata, if you will, in Erlang and elixir, we actually have a very confusing thing. A library that is called telemetry that is used in many popular libraries and frameworks to produce data that comes out of those libraries and frameworks. An example of this is if you're using Ecto, there's going to be telemetry events coming out, and this will describe your query time. So it will measure the time the query starts and the query ends. And it will produce an event that says, this is how long this query just took. And then something else will do something to collect, aggregate and report that data. So this is really useful for having a language agnostic way, a general API that you could use to produce data, but that data by default doesn't do anything. It doesn't go anywhere. You have to actually aggregate, collect that data and report it to something. So out of the box with the Phoenix framework, you're going to get telemetry. It's going to hook into a bunch of different events. And if you go to Phoenix LiveDashboard, you'll see different queries charted for Ecto, for your Phoenix routes, all those different things. And those are actually metrics. So these metrics are derived from these telemetry events. Every time a route is hit or a query is made, the telemetry event is fired. Something else, a telemetry handler is going to collect that. And then it might use something like the Prometheus exporter to roll those up into metrics that can be charted in Grafana or in the case of Phoenix LiveDashboard, it's just collected in memory and then used to produce that chart. So that's telemetry.
+
+
+Sundi Myint:
+Yeah, that was a follow up question. You mentioned Grafana and I know a lot of people, generally the industry uses Datadog a lot. How do you choose which tool is right? Is there one that's particularly good for Elixir or one that's particularly good for better observability? If that's the way to phrase that?
+
+
+David Lucia:
+Yeah, it's a good question. And it kind of comes back to a more fundamental question, which is like, what are the different types of data that you want to have coming out of your system? So when I think about observability, I think about four different things. I think about logs. So your standard logger, the thing that goes to standard out, typically in a production scenario, the ideal thing is to have structured logs, meaning like JSON formatted logs, that something can understand. You also have metrics, which is what we were just talking about, where aggregate information, charting things like the P99 of... The 99th percentile of your response time, the P50, all these different percentiles that you could chart over time, CPU utilization, memory usage, all these kinds of things. Then there's distributed tracing, which is I think the most fun one and one that I hopefully will get into the meat of very soon. But this is the idea of being able to see exactly where your program is spending time.
+
+
+David Lucia:
+And you can get really granular where you could see the request started at this time and ended it at this time. Towards the beginning, it made a database call that made another database call and another and another horizontal or diagonally going down a graph and you'd be able to see, oh, I have an n+1 query in my system. And so distributed tracing is a way of seeing where your system is spending time, all correlated together for one request, if you're doing a request response based system. And then what's really cool is the distributed part of it where you can make requests across services and the trace can actually carry between those two. So you could see, oh, I was blocked on this service and this service had a database call that took a really long time and that had a cascading effect that broke everything down. So distributed tracing, I think might be the most powerful of the observability tools.
+
+
+David Lucia:
+And then the fourth type of observability data that I look for is just error reporting. So really I have a very particular type of log. It was an error, go catalog it somewhere, and then I can reference it and come back to, and maybe collect some other contextual data about it.
+
+
+Owen Bickford:
+So we've kind of talked about application and maybe even machine type metrics where we're kind of monitoring memory usage, CPU usage, and so on and query performance response times. I'm also kind of curious if... I'm thinking of authentication authorization, are those events you would typically produce through telemetry as well to track new users or that any kind of authentication stuff that might be happening in your app?
+
+
+David Lucia:
+Absolutely. So observability telemetry is used for what is important to your business, period. So when we think about how do I choose what to observe in my system, there's some really good places to start, but as you get farther along, the things that you want to capture with telemetry are what is important to my business? So maybe one thing you really want to understand is new user signups. You can argue that this is actually a different part of the system. So maybe you actually want to put this in your analytics store in some OLAP database, maybe you're using Google analytics, or maybe you're using something like Amplitude and you want to put it in there because it's more of a business intelligence function. But there might be a really captivating reason to capture information about new users in your system because new users might go through different code paths than existing users. And so when you have a request coming in, maybe you want to include as metadata in a trace like the length of time the user has been a user in your system or something like that. And that could correlate to potential problems in your system.
+
+
+Owen Bickford:
+Going all the way into the details. Are we talking about tracing the user ID? Do you trace the whole... Do pass out the whole user strucked? I can't imagine that would usually make sense, but when you... Say I've got a telemetry event that says new user added, am I like tracking IDs or just new user added and that's it?
+
+
+David Lucia:
+Good question. So for telemetry in particular, and I have to come back to the second part of your question from before, which is what is OpenTelemetry? Because I think that's relevant here, but in a telemetry event you typically want to include as much information as possible. And the way telemetry was designed was so that it's very cheap to move this data around and I can get into how it's implemented, but it doesn't cost very much for you to add that extra data. And then when it's actually reported, the things that are listening to the telemetry events, they could decide which data to include in which data not to include. So in general, when you're creating new telemetry events, maybe you want to have something like new user for your application. You would go ahead and you'd include all of the information. And then in the reporter side of that telemetry event where you're rolling it up to a metric, that's where you choose whether you want to have a new user, the idea of the user versus not.
+
+
+David Lucia:
+This comes into a topic of cardinality. So when we are creating metrics, we don't want to have too high of cardinality, which is the number of possible options for that column. So a user ID would be a high cardinality column where that number is kind of unbounded. You can have many, many user IDs in your system. The reason you don't want to have a high cardinality value in your metric is because the number of metrics that you have now is going to explode. So each one has to be tracked individually and aggregated individually. And depending on what type of metric provider you use, that's going to be very costly with dollars or is just going to consume a lot of computing resources. So maybe this is a good time to talk about what... That's telemetry. It allows us to report data and then end up shipping that information somewhere.
+
+
+David Lucia:
+But OpenTelemetry is a standard. It's something that's actually language agnostic. So there's OpenTelemetry libraries for Go, for Java, for JavaScript, and for the BEAM. What OpenTelemetry is a specification that allows us to collect telemetry data and report it in a vendor and language agnostic way, and then be able to consume that data in whatever vendor tool that you choose to use. So maybe your team likes to use Datadog. You can collect, you can instrument your application with OpenTelemetry. You can then report it to the OpenTelemetry collector, which then can ship it off to Datadog. And if you decide that you don't like Datadog anymore, all you have to do is change the configuration of your OpenTelemetry collector and say, Hey, I want to go to LightStep now or I want to go to Honeycomb. And the idea is that that should be just a configuration change.
+
+
+David Lucia:
+What's really cool is that you could also say, Hey, I want to go to Datadog, LightStep, Honeycomb, Dynatrace, and New Relic, because you want to spend a lot of money and that's just something that you should be able to do, but you don't have to change your code. So I think what people are probably used to, if you've ever used an APM like New Relic or App Signal, is that you install an agent in your system and you have a very particular piece of code that you have to stick in a few places in configuration. Maybe you have to wrap certain function calls. With OpenTelemetry, there's just one standard and there's a way to hook into the typical frameworks and libraries that you might be using. So that you drop it in and boom, out of the box, you get metric information, tracing information, and soon logging information all out of one language agnostic framework.
+
+
+Sundi Myint:
+Does that framework cost money to use OpenTelemetry? It sounds like a service.
+
+
+David Lucia:
+So OpenTelemetry is all open source. So you could find it on GitHub. The observability working group from the Erlang Ecosystem Foundation is the one who is writing the Erlang Elixir instrumentation libraries that you'd find under the OpenTelemetry prefix in hex. And these are built to the specification that's created by the OpenTelemetry standard.
+
+
+Sundi Myint:
+I guess what this makes me think of is, let's say we're starting a new project for a client and we know we need to add some kind of observability tools. We might reach immediately for Datadog because our client has used them in the past. So we just start figuring out how do we start building out a system that can support sending data to Datadog. But then we find out about OpenTelemetry and we want to go that route. We want to install it that way so that we can switch it if we need to, or they want to because they've indicated that they might be switching, but maybe they don't want us to take the time to put that together. How do you make that argument for OpenTelemetry versus just setting up like a basic observability situation?
+
+
+David Lucia:
+That's a great question. So I guess the first thing is, do you want to be locked into Datadog going forward? Right? Do you want to have that vendor lock in? Because if you start to depend on one vendor like Datadog and you add instrumentation all particular to them, it's going to be very hard to switch over time and your bill is probably going to continue to grow with them, which maybe that's fine for your organization. OpenTelemetry is designed to be really easy to get started with. And part of the draw is that there is drop in libraries that add instrumentation to your favorite frameworks like Ecto, like Phoenix. I wrote one for Commanded. There's one for Open, all of these different libraries that you're already using.
+
+
+David Lucia:
+It's pretty much just one line of code. You drop it in to your mix file you then in your application supervisor, you just make one call, function call to it, and then boom you're producing metrics and traces for all of those things. So I would say if someone is trying to ask you, should I use a particular vendor or should I use OpenTelemetry? I would say first you probably want to just use OpenTelemetry so that you can make the choice later to switch to something else. And two, most of the vendors are using OpenTelemetry going forward as their standard way of integrating. I think Datadog included in that.
+
+
+Owen Bickford:
+Yeah, I've been introduced recently to the Spandex Datadog package on hex for-
+
+
+Sundi Myint:
+Ugh, Spandex. Sorry, every time I recognize that they named themselves spandex, I get mad and we move on, but I call it out every time. Continue Owen.
+
+
+Owen Bickford:
+Well, sorry to inflict this pain on you, but no, I'm pulling up a list of OpenTelemetry searches in Hex and hilariously, there's a package called OpenTelemetry Telemetry.
+
+
+Sundi Myint:
+Stop it. We are literally the worst at naming things. Like we developers as a species.
+
+
+David Lucia:
+So that library is for making it easier to create a bridge between Telemetry and OpenTelemetry. But yes, that is a library.
+
+
+Sundi Myint:
+They should have called it bridge. Nothing else. Just bridge. Oh my gosh. And on the flip side, Dave, what if you're trying to sell the idea of observability at all? What if a client just wants it done and dirty and they're just like, I don't want you to spend time on data. I mean, usually they want data, but they don't really want you to spend time on data.
+
+
+Owen Bickford:
+What could go wrong if you don't have telemetry?
+
+
+Sundi Myint:
+Right.
+
+
+David Lucia:
+Yeah. Well, I mean really it comes down to what kind of business do you have and if something goes wrong, what does that do to your reputation if you're not able to resolve the issue quickly? Right? So let's say that
+
+
+David Lucia:
+The worst case scenario, you go to your website and it's just 500. You want to be able to get to the root cause of that problem very quickly, so you need to figure out what's happening, diagnose the problem, fix the problem and deploy it to production, and ideally you could do that in minutes or a few hours. There's been very public outages that have happened for days, weeks, and that could be really, really bad and your customers are really not going to be happy. So the idea of investing in an observability, of understanding your running system, is in protecting your reputation as a business. You want to make sure that you have reputation for uptime, for a reliable product. So that's what I'd say to anyone who's like, "Ah, I don't know about observability." Maybe you want something like quick and dirty and you want to get just something running really quickly.
+
+
+David Lucia:
+Depending on what you're using, I know that Heroku is not so popular these days but with something like Heroku, you can get a lot of logging information and metrics out of the box that just integrates right with the Heroku ecosystem. With stuff like Phoenix, we've got Phoenix LiveDashboard, and you've got some metrics in there. You can actually even see some logging. So even in the BEAM ecosystem, we have some very base level observability that we get. Things like Observer that are actually built into the BEAM and shipped with the BEAM, that's a form of observability. It's really anything that helps you diagnose problems or understand your system as it's running better and faster, and depending on how important it is for you to resolve issues quickly and the complexity of your system I think necessitates how much investment you put into observability. I think...
+
+
+Sundi Myint:
+Yeah. You actually just said something too that reminded me that... Can you remind everyone, where did you start before you were working in Elixir? Like what languages?
+
+
+David Lucia:
+So before I was in Elixir I was working for Bloomberg and we relaunched the bloomberg.com website all in no JS. So I was doing JavaScript for a while. And before that I was in C++.
+
+
+Sundi Myint:
+So with that, can you tell us, is there anything in your experience, like your own personal experience that Elixir lends better for observability? It kind of sounds like the BEAM has some things built in, but is there anything else?
+
+
+David Lucia:
+Yeah, I mean, what's really nice about Elixir and Erlang this ecosystem is that you're able to ask a lot of questions of the system and get answers in ways that you just would not be able to. So am I thinking of node? I could never just SSH into the box, running my node JS system, get a remote connection to that box and run arbitrary code inside the system or connect it to an observer. So this is just an unfathomable thing to do in most languages. And I think the introspect ability of Elixir and Erlang at runtime, things that are built into the core Erlang libraries into Elixir itself, make it really good for being an observable language. Now, if you ask the people who work on OpenTelemetry for Erlang and Elixir, they might tell you actually, something very different because my understanding is actually very difficult to build tracing instrumentation libraries into Erlang and Elixir because of the process concurrency nature of it. So being able to share span information...So talking about the implementation of OpenTelemetry Erlang and Elixir, a challenge is actually that because of the concurrent nature and the process abstraction in the BEAM, my understanding from the OTel working group folks is that it was actually really difficult to implement a lot of the core functionality that enables us to have things like distributed tracing in Erlang and Elixir. So while there's some really good primitives that we just don't have in other languages, things like Observer, things like being able to easily report like CPU metrics and things like that, the language itself being functional and concurrency driven makes it actually really hard to build the abstractions that now we could take advantage for free because of all that hard work that went into OpenTelemetry.
+
+
+Owen Bickford:
+When you said SSH into a box, I got flashbacks to a very non telemetry application. So I think we've all, if we've been deploying apps to production over the years and something's gone down and you've been asked for an answer, what that means without telemetry is logging into a machine, hopefully through SSH, digging around for logs, digging through the logs and trying to find the valuable piece of information that actually brought the application down. Whereas it sounds like with telemetry, the benefit here is you're getting all this kind of information surfaced in a much more structured and searchable way through these different services. And that helps you find the answer and therefore solve the problem much more quickly.
+
+
+David Lucia:
+Right. So the main thing with distributed tracing in particular, which as I said, I think is one of the more interesting types of data that we can get out of the system. When I use tools like LightStep and Honeycomb, which I think are kind of ahead of the pack of observability tools. The thing that's so interesting about them is I can go in and I could say, "Okay, here is the request for my homepage." And I could see a graph of all of these different traces coming in and maybe their P99 values. And I can find, "Oh, here's one that's really high. Here's a point on the graph that's really high." And I can select that. And I can select a time when maybe the graph was all low. So we're having a performance regression. There's a point in the graph really high. I could select where it was really low.
+
+
+David Lucia:
+And then it can do a correlation analysis where it says, okay, of these spans that have this value really high. What's different about these spans than the spans that had this value really low? And all of the attributes that I'm collecting in my telemetry data so maybe I'm collecting user IDs, maybe I'm collecting, is this a new user or not? Is the first time they've logged in, I'm collecting their geographical information. I'm collecting what's their user agent. So tools like LightStep and Honeycomb, they get this data to them on the spans that are instrumented from our OpenTelemetry Phoenix library. And they could suss out and say, "Oh, well, for those spans that are coming from New Jersey, these ones are slower than the rest of them. Okay. Well, what's different about my users coming from New Jersey?" And you can then dig into those and look at a trace that is exemplary.
+
+
+David Lucia:
+And so you'll go in and you'll see, okay, well this New Jersey trace, the database is taking a really long time. And then you go and you look at your database metrics and you see that for some reason, that database is going into swap and spending a lot of time going to disk and you restart that database or you spin up a new one and that solves the problem, these kind of tools that help you discover that path of users in New Jersey correlate to my US East One database being faulty. That's a really hard problem to get to the bottom of, but these tools that allow you to observe all this information and correlate it in real time and ask the system questions. This is the thing that is so valuable and why I am so excited about tools like LightStep and Honeycomb is that they allow you to ask those questions in real time without actually having to log into your box and do some very dangerous things.
+
+
+Sundi Myint:
+So Dave, can we do some no code editor in front of us? Pseudo coding? Yes. We've started a new Elixir project. We did the generating, whatever we had to do, and we're just trying to implement some basic observability, just an intro place for somebody who needs to add it, but doesn't really know a lot about it. Where do we start? What files are we opening?
+
+
+David Lucia:
+So first things first, you should have logging out of the box. So you've got that one checked off, great.
+
+
+Sundi Myint:
+With Logger, right?
+
+
+David Lucia:
+With logger.
+
+
+Sundi Myint:
+Okay.
+
+
+David Lucia:
+So we're done there. If we've generated a Phoenix application, they've probably already spun up some metrics reporting that has grabbed from Phoenix live dashboard. So great. You've got something basic there too, but now we want to get a little bit fancier and we want to collect even more interesting metrics that we can produce and maybe sent us something like Prometheus and Grafana, which are a tool for observing metrics. Well, there's a great library by Alex Koutmos called PromEx. And this not just helps you instrument your application with these metrics, but we'll actually generate kind of all the standard charts for you that are really annoying to set up by hand. So you put PromEx into your application, you configure it in probably your config, runtime or production, and this will ship all of these metrics charts to you for you to Grafana. And then you'll be able to see your ecto queries and your request response times, all these kind of things charted out for you right out of the box.
+
+
+David Lucia:
+So that's a great one and super easy for getting started. From there, I think I probably introduce something like Century. So I put Century into all of my apps and this is for error reporting. So you get error reporting with logging. But the thing that Century does is that it helps you catalog these errors. So it will grab extra contextual information like if the error happened in the context of a request, what the IP address was, and maybe the logged in user and all this stuff. Okay, great, I've got a way of cataloging errors and then comes OpenTelemetry. So OpenTelemetry is something that you're going to, of course install probably like at a minimum three libraries, you'll install the OpenTelemetry library and then you'll install OpenTelemetry Phoenix, OpenTelemetry Ecto. That's probably the most common setup here.
+
+
+David Lucia:
+You're going to have to configure how you want to ship, whatever data is coming out of OpenTelemetry. So you're collecting trace and span information. You need to ship that to something that you can then use to search and correlate data and find out what's going on. And I think that's where the bulk of the configuration is going to happen. And probably what trips up people the most is, how do I set it up? Do I need to use the OpenTelemetry collector? You don't have to, but maybe you should, depending on the complexity of your application, but really all you're doing is you're installing the libraries, you're configuring where it's going, and you're dropping in those framework level instrumentation libraries. And that really is going to get you very, very far because the most important thing or place to start when you're instrumenting your application for observability is to start at your inputs and your outputs.
+
+
+David Lucia:
+So you want to know the requests coming in. You want to know the queries going out to your database. Maybe if you're writing to files, or if you are talking to S3 or writing to a message queue, these are all great places to instrument your application with spans using the tracer in OpenTelemetry. And this is where you can start to get into the important parts of your business like we were talking about before. So if you, new user signups are really important, you want to put spans around the critical operations of what it means to be a new user. Maybe there's a complex onboarding flow that your users have to get through. So you probably want to instrument all the different steps in that process and make sure that if there is critical places where something that can go wrong, that you have a way to capture that information. So that then you could go to your tool of choice and ask some questions and get some answers if some user is having a problem.
+
+
+Sundi Myint:
+Okay, so follow up to that.
+
+
+Owen Bickford:
+So I want to throw something out here before we forget. So I'm just going to throw it out here. We'll come back to it, but we've got to talk about Observer at some point, obviously, right? Elixir, Erlang, Observer, but I'm curious, can you go too far with observability? Can you add telemetry events for every single function and get yourself into trouble by...
+
+
+Sundi Myint:
+All that data know where to go.
+
+
+Owen Bickford:
+Emitting too much. Right?
+
+
+David Lucia:
+Yeah. You can certainly, and you can do this in a number of ways, which can get you in trouble. So one, you can add too much instrumentation where imagine you're just every single function you're capturing in a span, right? So if you go to your observability tool, you'll literally see your stack trace as you would, if an exception were to happen to your application, and maybe that's valuable information to you. But the problem is, is that you're not going to be able to record all of that information informatively or collect it in a way that when you're shipping it, it's going to be cost efficient or memory efficient. You're probably going to have to end up dropping a lot of that data because it's just no way that you're going to be able to ship it in time to over the network, to these observability tools, or even just out of your own system. There's a cost, a fixed cost to producing telemetry data. And ideally it's really fast, but when you overdo it, it could actually be something that hurts the performance of your application
+
+
+David Lucia:
+... in and of itself. So again, when you're thinking about where do I start with observability? Think about the boundaries, the edges of your application, and that's the place where you start. And then over time, you're going to start to know the important bits of your application, maybe where things tend to go wrong or just that it's highly valuable to your company or your product. And that's the place where you add.
+
+
+David Lucia:
+But over time, you might find that, hey, there's places where we added observability that just haven't been useful. And it's actually okay to do some gardening and some weeding and pull out those weeds. We don't need this and that's okay. So I actually gave a talk about this maybe two summers ago, and I said that observability is a garden and you need to tend that garden and you need to plant some trees every spring and pull out the weeds too.
+
+
+David Lucia:
+So it's kind of a never ending process, but it's to serve you as kind of the person who's operating this software. It's there to help you. And that's really the most important thing. It's for the human, it's for no one else.
+
+
+Owen Bickford:
+Yeah. It's just like code. Is this code still giving me value? If not, then maybe it's time to delete that code. And yeah, I think anyone coming to Elixir or Erlang for the first time or early on when you're learning about these tools and these... The VM and everything, one of the superpowers we have that almost no other language is, at least that I'm aware of, would have is observer. So with the barebones Elixir application, once you start it, let's say you run IEX with your application. You can just run observer.start, and then you get this little window...
+
+
+Owen Bickford:
+Assuming you've got all the right dependencies on your system. You will have this window that pops up, that shows you the state of your application and the supervision tree, all this information about the machine that it's running on and how many resources it's using. And you don't have to add anything to get that.
+
+
+Owen Bickford:
+So it's really amazing that... That's a really nice way to be introduced to observability and the value. And I think all of the telemetry tools and observability tools that we're talking about help us extract that out into other systems where it's a little bit more easily accessible.
+
+
+David Lucia:
+Yeah. What's so cool about observer is that, okay, we talked a lot about metrics now and hopefully I haven't belabored it too much, but like, okay, you get CPU, memory data fine.
+
+
+Owen Bickford:
+Right.
+
+
+David Lucia:
+That's cool, that's kind of standard across any system. But I think the coolest thing is the visual representation you get of your system, that tree, that application supervision tree that you hear about, you see in your code, but you could see visually represented as a tree, and then go and interact with it, interact with the tree and see what's the state of this process. What's the memory of this process? When was it last garbage collected? These are all things that just come with Elixir and Erlang, which is super cool. I think you need wxWidgets and I think some Java thing actually installed to be able to run that correctly.
+
+
+Sundi Myint:
+Nobody's got time for that.
+
+
+Owen Bickford:
+Well, and yeah, no one really does have time for that. But I think what's really exciting to me is also that with all the work happening in Livebook, that's going to make it even easier. You won't need all those system dependencies. You'll just be able to run a Livebook that might illustrate the same exact supervisor process and even give you more powers than we have already.
+
+
+Sundi Myint:
+We're heading to the future.
+
+
+Owen Bickford:
+The very near future.
+
+
+Sundi Myint:
+The very near future.
+
+
+David Lucia:
+Livebook is so cool. And what we're able to now chart and the mermaid graphs of the same thing in observer of seeing the application supervision tree is mind-blowing, is so cool. This made me think of something that I should have mentioned before. There's an open ticket in the OpenTelemetry Erlang project. And the idea is what if there was just a mix Phoenix New or my favorite, mix Surface and NET, where you run that in an existing project and boom, you get OpenTelemetry, all installed for you with all of the libraries and bridge libraries that you need without doing any work.
+
+
+David Lucia:
+And maybe you say the vendor you want to use and boom, you get some extra configuration. So this is a project that has not been started yet. It's just an idea that Tristan Sloughter, who's on the OpenTelemetry working group for Erlang, that he opened up and got me excited. So there's some work that's being done on some other fundamental libraries that make it easy to work with the Erlang AST or sorry, the Elixir AST, to be able to modify code.
+
+
+David Lucia:
+So I'm waiting on a library called Recode that is going to make it easier to do this, but maybe at some time in the near future, you'll just be able to run mix OTEL and NET and boom, you'll have observability added to your project with really no work on your end.
+
+
+Sundi Myint:
+That would be the best. We also have a follow-up question for you, Dave. We have also observed that pineapples are important to you. Why?
+
+
+David Lucia:
+Well, I have a pineapple tattoo.
+
+
+Sundi Myint:
+Okay.
+
+
+David Lucia:
+So if you want to see that, you can. It's a pineapple with sunglasses. Okay. Long time ago, me, my now wife and my friend, we were out in New York City and we had a late night and my friend went to a bodega, which is a corner store for those who don't live in New York or another city that calls them bodegas. I don't know who else does. Anyways, he bought a pineapple from a corner store and he kind of went off on his own. And later in the night, we ran into him and he was just kind of eating the pineapple whole, skin and all just eating it. And I just caught eyes with him and we started hysterically laughing and it became an inside joke from then of pineapples. And my friend got really into drawing pineapples and just became a thing in my life that's thematic. So yeah, I really like pineapples just because it reminds me of good times and my friends.
+
+
+Sundi Myint:
+Well, we...
+
+
+Owen Bickford:
+Last question, pineapple pizza.
+
+
+Sundi Myint:
+Oh my gosh.
+
+
+Owen Bickford:
+Are we pro, anti?
+
+
+Sundi Myint:
+Poor Amos is going to come out of the woodwork and be like, "[inaudible 00:51:34]."
+
+
+David Lucia:
+Is Amos for or against pineapples?
+
+
+Sundi Myint:
+AI believe he's against it.
+
+
+Owen Bickford:
+It should not affect your opinion whatsoever.
+
+
+David Lucia:
+Well, my opinion is that I'm neutral on pineapple pizza. I haven't had it in a really long time. I'm willing to try it again. I'll try almost anything once, but it's not something that's really maybe you want to come back for it. So maybe I don't like pineapple pizza.
+
+
+Sundi Myint:
+Well, I will say after having just recently completed all 10 hot sauces in the Hot Ones hot sauce challenge, humble bragging here. I will own up to it. The second sauce is the pineapple sauce. And I think not spice related, that was actually one of my favorite sauces in the lineup that I actually wanted to save talking about it until today.
+
+
+Owen Bickford:
+You weren't a fan of Da'Bomb?
+
+
+Sundi Myint:
+Who would be, seriously? Crazy people.
+
+
+David Lucia:
+Oh man. So Allison who worked with me at SimpleBet, she lives in Kansas City and she brought me Da'Bomb, which I believe is from Kansas City when she was visiting in New York. And I tasted it on my finger and was very, very upset-
+
+
+Sundi Myint:
+Life choices?
+
+
+David Lucia:
+... with myself for probably the next hour-and-a-half. Yeah, we tried it in the office. We were going out to dinner and for the next hour-and-a-half, I was just profusely sweating.
+
+
+Sundi Myint:
+Yeah, it doesn't go away. It builds and then leaves and then goes and then builds again. I will say at Elixir conf, there was a wonderful sponsored happy hour in which I met Allison. And she approached me with You talked to Dave about wings and I was not there. You even told me to look for her. And I was like, "Which Dave?" And she goes, "Lucia." And I was like, "Oh, what do you mean?" Hot wings? Like chicken wings. Because I was sitting here thinking angel wings, bird wings, goose wings. I don't know. I have never been so thrown off guard-
+
+
+David Lucia:
+Oh man.
+
+
+Sundi Myint:
+... by Dave about wings in my life. Allison, shout out to you. It was so great to chat with you about Da'Bomb and the Da'Bomb hot sauce. I got to... Yeah, Da'Bomb hot sauce. It's just ugh, gross. Yes.
+
+
+David Lucia:
+It's something-
+
+
+Sundi Myint:
+Well, I'm glad we did get to talk about it.
+
+
+David Lucia:
+There's some other terrible hot sauces. And I mean terrible in that they're just so hot that it's just, I don't know why would anyone eat them. But I think the worst two I've had are Death Nectar, which-
+
+
+Sundi Myint:
+Sounds awful.
+
+
+David Lucia:
+... is in a black bottle. It just looks like it should kill you and it might. And then The Last Dab by Hot Ones is really, really, really hurts the soul.
+
+
+Sundi Myint:
+It didn't hurt... When you do eight, nine and 10 within the 30 minutes of each other, The Last Dab doesn't hit you like eight does, like Da'Bomb does. But I will say it lasted the longest in that it was minutes and minutes after I had eaten it, I thought I was over the best of it. I was the person who ate it and then was like, let me immediately go drink some milk. I'm not ashamed. And one of my friends came over in the middle of that. She was like, "Oh, hey, how are you?" And I just looked at her and I started crying, but my eyes were crying, but my body didn't feel it. And she was like, "What's happening right now?" And I was like, "I think I just did 10 and I'm reacting still, still."
+
+
+David Lucia:
+So can you describe what was the context of you eating all of these wings?
+
+
+Sundi Myint:
+Oh, I just really liked the Hot Ones show on YouTube and I wanted to do it and I wanted to do that for a year. I achieved one of my year goals this past weekend.
+
+
+David Lucia:
+So do you do it with friends? Did other people do this with you?
+
+
+Sundi Myint:
+I just had my friends come over and I poisoned them all.
+
+
+David Lucia:
+Are they still friends with you?
+
+
+Sundi Myint:
+They were like, "That was a fun, creative and unique party idea."
+
+
+David Lucia:
+Well, I saw your... I forgot what you called it. It was like the cool down board. It was-
+
+
+Sundi Myint:
+Antidote board.
+
+
+David Lucia:
+... the antidote board. I saw a picture of this and it looked amazing.
+
+
+Sundi Myint:
+It was basically-
+
+
+David Lucia:
+It was so nice.
+
+
+Sundi Myint:
+... like a charcuterie board.
+
+
+David Lucia:
+I'm very jealous.
+
+
+Sundi Myint:
+But of the things that would cool you down; cucumbers, ranch dressing, carrots, radish, lettuce, just the good stuff. I also had coolers full of ice-cream-
+
+
+David Lucia:
+It looked delightful.
+
+
+Sundi Myint:
+... everywhere.
+
+
+David Lucia:
+Ooh.
+
+
+Owen Bickford:
+Ooh.
+
+
+David Lucia:
+Wow.
+
+
+Sundi Myint:
+Yes.
+
+
+Owen Bickford:
+Well, so congratulations, Dave. You made it through the gauntlet. 10 wings down. Point to the cameras; this camera, this camera, this camera.
+
+
+Sundi Myint:
+Any final plugs?
+
+
+Owen Bickford:
+Do you have any final plugs for the audience?
+
+
+Sundi Myint:
+Oh, [inaudible 00:56:17] doing his best [inaudible 00:56:19] impression right here.
+
+
+Owen Bickford:
+This camera, this camera, this camera.
+
+
+David Lucia:
+Plugs for the audience, I'm hiring at Bitfo. If you want to come work on some fun stuff in NextJS and Elixir on the back end with TimescaleDB, Surface, OpenTelemetry, Lightstep Honeycomb, come talk to me. I swear I'm friendly. You don't have to like pineapple pizza if you want to come and talk. Yeah, and just really, thank you for having me on. This was a lot of fun. I think I have to do some more writing because as we've had this conversation, I've realized it's really hard to articulate observability. It's a really complex and broad topic. So if you were confused about any bit, please hit me up on Twitter, that's probably the best place, and I'm happy to chat more with you and help you get started.
+
+
+Sundi Myint:
+And are there any projects that people could get involved in? Anything that could use some help? I think you mentioned a few open issues, places.
+
+
+David Lucia:
+Yeah, so joining the Erlang Ecosystem Foundation and picking a working group, if you're excited about what we talked about today, I'm sure the observability folks would love some help. So there's an observability working group that you could join and anyone is free to participate. Well, not free to join, but free to participate once you've joined. On GitHub, there are a bunch of open issues for the OpenTelemetry projects. There's also the whole... Is it Apache Cloud Foundation? I forget what the name of it is, but there's many ways to get involved with OpenTelemetry and GitHub is probably your best place there.
+
+
+David Lucia:
+Selfishly, I have some own projects that I'm working on, particularly with TimescaleDB, that I'm looking for people who are interested in contributing. So again, come and reach out to me if you want to get involved there. There's a lot of low-hanging fruit stuff that if you want to get involved in open source for the first time, it would be a great opportunity.
+
+
+Sundi Myint:
+Awesome. Well, thank you so much, Dave. This has been great. I feel like I've learned a lot and having read your blog post ahead of time was a little bit of a primer. But again, you said it's a very broad subject and I think you did a great job of covering it all. Yeah.
+
+
+David Lucia:
+Thank you.
+
+
+Sundi Myint:
+That is it for today's episode of Elixir Wizards. Thank you again, Dave Lucia for joining us. I am Sundi Myint, your host and my co-host is Owen Bickford. Elixir Wizards is produced by Hangar Studios and is brought to you by SmartLogic. Here at SmartLogic, we build custom web and mobile software. We work in Elixir, Rails, React, Flutter, and more. Need a piece of custom software built, hit us up. Don't forget to like, subscribe, and leave a review. Your reviews help us reach new listeners. And you can find us on Twitter @SmartLogic or join the Elixir Wizards discord. The link is on the podcast page and we'll see you next week for more on parsing on the particulars.

--- a/podcast/elixir-wizards/transcripts/s9e2-kate-rezentes-simplebet.txt
+++ b/podcast/elixir-wizards/transcripts/s9e2-kate-rezentes-simplebet.txt
@@ -1,0 +1,936 @@
+Sundi Myint:
+Welcome to Elixir Wizards, a podcast brought to you by SmartLogic, a custom web and mobile development shop based in Baltimore. My name is Sundi Myint, and I'll be your host. I'm joined by my co-host, Owen Bickford. Hey, Owen.
+
+Owen Bickford:
+Hey, Sandy.
+
+Sundi Myint:
+This season's theme is Parsing the Particulars. Today we are joined by special guest, Kate Rezentes from Simplebet, and we'll be diving into the particulars of GenServer. Hey, Kate.
+
+Kate:
+Hi.
+
+Sundi Myint:
+Thank you so much for being here. How are you doing?
+
+Kate:
+Good, how are you guys? Thank you for having me.
+
+Sundi Myint:
+Good times, good Times. Today actually, at SmartLogic, it's our professional development day, so we've been jumping around learning different stuff. We made sure to brush up on GenServers this morning. Do you guys do anything like that at Simplebet? Any kind of learning days?
+
+Kate:
+Every day is a learning day.
+
+Sundi Myint:
+All right.
+
+Kate:
+I don't recall any professional development days. I'm always learning new things.
+
+Sundi Myint:
+Yeah, that's super fair. I think we talk about this all the time, that the best way to actually learn a new thing is to actually do it, which is a lot of the impetus for this season. Because sometimes when you're just like, "Oh, I need to generically learn a thing and you pull up a project, it's like, 'Eh, not super helpful.'"
+
+Kate:
+No.
+
+Owen Bickford:
+Before we dive into the particulars of GenServers, we met back at ElixirConf Austin. Was that your first developer conference?
+
+Kate:
+No, actually. I'd been going to programing conferences with my mother, Michelle Rezentes, Mickey Rezentes, since I was 15. A lot of it was RubyConf and then Ruby on Rails and then We Rise and then ElixirConf in Austin and then ElixirConf in Colorado.
+
+Owen Bickford:
+Okay. So in the past year, how many have you hit up?
+
+Kate:
+After the Austin one, the ElixirConf in Austin, we hit one in Raleigh. I think it was called All Things Open. And my mother and I both talked there. We gave the same talk that was given in Austin.
+
+Sundi Myint:
+There's so many conferences, it's hard to keep them straight, right?
+
+Kate:
+Yeah. Well, I have to say that ElixirConf has by far been my favorite.
+
+Owen Bickford:
+Oh, nice.
+
+Sundi Myint:
+The conference as a series or the last one?
+
+Kate:
+The last one, definitely. But both of my experiences at ElixirConf have been good. I've met a lot of great people, and I was more familiar with the technology as well because I'm pretty new to actually programming.
+
+Owen Bickford:
+And you landed a job, right? Did that happen at ElixirConf last year or sometime after that?
+
+Kate:
+Yeah, I went to the speaker dinner with my mother, and Dave Lucia was there who works at Simplebet. Apparently my mother had interviewed with them three years ago. And he remembered my mom. And he was super nice. And we talked to him. I was on another podcast after Austin, and he reached out to me after that and got me hired.
+
+Sundi Myint:
+Nice. And your episode, Kate, is coming right on the heels of Dave's episode, so this is just nice continuity.
+
+Kate:
+Oh, really?
+
+Sundi Myint:
+We love it. Absolutely.
+
+Owen Bickford:
+That's what they call synergy.
+
+Kate:
+That's awesome. Yeah. David's one of the nicest people I've ever met. He's super nice.
+
+Sundi Myint:
+He absolutely tolerates all of my food photos, even though he's like, "Sundi, please stop. These are so wonderful, but I can't eat these."
+
+Owen Bickford:
+See, I know Dave's nice. I've met him at ElixirConf in Austin last year. But he'll stick out in my mind because he, in his infinite wisdom, named his son Owen. So [inaudible 00:03:38]
+
+Sundi Myint:
+Ah, yes. We did just talk about this. Our listeners who are just going episode to episode are like, "Wow, I'm caught up here." But we're episode two right now. Yeah, with Dave we dove into the particulars of observability, and we're going to talk about GenServers today. Kate, this came up at ElixirConf with us. Can you just talk to us about where GenServers as a subject came from?
+
+Kate:
+Okay, we were sitting down and waiting for a keynote to start. Was it Chris McCord's keynote?
+
+Sundi Myint:
+I think it was probably the keynote of the day, so it was Chris Granger.
+
+Kate:
+Okay. Anyway, my mom and I were just chilling at a table, and Sundi came down and sat next to us. And she asked me what I knew about GenServers. And I was like, "Uh, very little." She's like, "Perfect. Can I teach you some?"
+
+Owen Bickford:
+What do you know about GenServers?
+
+Kate:
+Like, "I just started, I don't know a lot." I've done a little bit of things. I've tried to learn more with them, but just not something that has really grabbed my interest a lot in the past.
+
+Sundi Myint:
+Yeah, this comes up a lot with... And for the background here, Kate is new to Elixir; less than a year, right? In the job space at least?
+
+Kate:
+In the job I've been six months.
+
+Sundi Myint:
+Six months-
+
+Kate:
+Seven months.
+
+Sundi Myint:
+Right.
+
+Kate:
+Yeah.
+
+Sundi Myint:
+So, that's where we are right now: September, 2022, for those listening in the future. And there's a certain number of things you hear as a newbie to Elixir. And it can be very frustrating when you're getting started to start Elixir and people are just throwing out "OTP, "ets," "this GenServer thing," and then "observability and telemetry" and then just these words that people just throw out as if you're just supposed to know them when you're just picking up a language, which is just generally frustrating. But GenServers is one of the ones that come up a lot. I honestly do not remember sitting down just asking you point blank about GenServers, but let's say that's what happened.
+
+Kate:
+How did you recall it?
+
+Sundi Myint:
+I think I asked you what you learned recently at work?
+
+Kate:
+Yes. Yep. That's accurate. I was summarizing the conversation.
+
+Sundi Myint:
+That's fair. No, no, no. That would be funnier, but I would've felt like I was assaulting you with knowledge.
+
+Kate:
+Okay. I think my humor, I like the really abrupt things in life. So, I tell stories abruptly, and it might not sound accurate to some-
+
+Sundi Myint:
+Oh-
+
+Kate:
+... people-
+
+Sundi Myint:
+... but they're funny.
+
+Kate:
+... unfortunately. Oh, thank you.
+
+Sundi Myint:
+Yes, they're funny. When we were going to take a picture with Todd, Todd Resudek was taking photos at ElixirConf. And I was like, "Oh, Kate, we should get a picture." And then Kate goes, "Todd, photo."
+
+Kate:
+And he was 20 feet away too.
+
+Sundi Myint:
+I was like, "Oh my God, that was so aggressive. But I love it."
+
+Kate:
+Well, we know Todd. Todd's great.
+
+Sundi Myint:
+Yes. And it was a great photo.
+
+Owen Bickford:
+And he didn't have to guess what you were asking. He's like, "All right, I guess they want a photo."
+
+Sundi Myint:
+Yeah, sometimes with developers you got to be straightforward, straightforward. We've talked about a little bit about your background and your pathway. But just to round it out in a rounded manner, one of our engineers and one of our new podcast hosts who's not with us right now, wanted to make sure that we asked you about your experience in the industry so far, particularly because you two were the only engineers that at least he saw at ElixirConf there were roughly in the same age range, experience level. So he was really curious about your experience in the industry so far.
+
+Kate:
+Yeah. Honestly, when I was coming in, I had heard so many horror stories about bad communication at work and all these tire fires but I've had a wonderful time at Simplebet so far. I've learned so much, and the environment that I'm in is very positive. So as far as my reflection on my experience so far, I've really enjoyed it. Was that the specific question? Was that the answer to the question, or did I go off on a rabbit trail?
+
+Sundi Myint:
+Yeah, that was the answer, just to find out what your experience has been like. Particularly as a junior engineer and when it comes to learning, I think is maybe the more specific way to ask that.
+
+Kate:
+Yeah, I feel like as a junior engineer, the biggest things... Which I don't know because I'm a junior, so when I become a senior maybe I'll think differently/ but just being able to ask questions and work a lot, I think that's where I've gained most of my experience and confidence. The biggest thing I've learned in the past month, I talk to my team lead about this all the time, is I post all of my questions in a public channel instead of DMing people. And that has been, I guess, the biggest maturing point for me so far because you just learn a lot more when you can formulate your question and are confident enough to post it in a public channel. And I feel-
+
+Sundi Myint:
+The more people will answer, right?
+
+Kate:
+... safe doing that. More people answer. People you wouldn't expect. And you're, "Oh, I didn't know you had months of experience in that area of the code base. This is amazing."
+
+Owen Bickford:
+Yeah, 100%. Well, typically if I'm asking a question, I'll post it in a public channel as well. That's my default because A, I'll get a better collection of responses. But also, if it's work -elated, there'll be a little bit more visibility that I'm working on a problem, and other people on the team can see what's going on. But yeah. I'm kind of curious, if we go back a little bit to this conversation at ElixirConf, and you bring up GenServers is maybe something you're either interested in or coming across for the first time. What's the context? As much as you can share, how did Gen servers come up in the work that you're doing At Simplebet?
+
+Kate:
+I did some work on this Epic where we were working with state, we were trying to manage state. And that's where we were using GenServers and OTP and property tests. And oh my word, that was a lot. I tried to read a book on it, and that was... Okay, honestly, that was terrible. I did not like that book. It was boring.
+
+Sundi Myint:
+What was the book?
+
+Kate:
+I couldn't [inaudible 00:10:13].
+
+Sundi Myint:
+You can throw it out there.
+
+Kate:
+Well, okay, I don't think it's that the book is terrible itself. It's just my ability to comprehend it. I don't want to be dissing other books. It was Property Testing and Elixir, I think. I have it on my desk out here.
+
+Owen Bickford:
+I've got that one. Property-based Testing with PropEr and Erlang or something like that?
+
+Kate:
+Yes. Yeah. And it's got the pink bar across it. Pragmatic programming is most of the textbooks that my library and my mother's library consist of. We're like a joint library, so I'll just grab books out of there. And then I-
+
+Sundi Myint:
+That's so-
+
+Kate:
+.... tried to-
+
+Sundi Myint:
+... convenient.
+
+Kate:
+It is very convenient. And then, when the books are out of date, she chucks them. So, I'm not reading bad stuff.
+
+Sundi Myint:
+My God, I'm picturing Nikki throwing the book. She's on roller skates. Her hair is flying behind her. There's a whole thing happening in my head right now. I've never thought about throwing away the books when they get old, quote, unquote, but that makes sense.
+
+Kate:
+Yeah, well, if they're outdated, she places them in the trash. Okay? So, it's a less-
+
+Sundi Myint:
+Okay, that's a little more-
+
+Kate:
+... abrupt action.
+
+Sundi Myint:
+No, I don't think it's a diss. It's constructive criticism that books are something to help us, they're a resource to help us. If they don't help us, then that's fine. Some of us aren't book people. Sometimes it's literally marketed towards a senior engineer or somebody who's worked in Elixir for a long time. So yeah, that's fine. So you tried reading the book, didn't work. Where did you go next?
+
+Kate:
+I no longer had to work on maintaining the state. It was a senior programmer that had said he read the book. And I had known nothing about that area of Elixir, so that's why I got the book. And he said it had taken him a long time to get through, and it was going to take me an even longer time to get through. And I just didn't.
+
+Owen Bickford:
+Those books, sometimes you've got to get it at the right time. That book, I think I've taken a couple of attempts to get started with it and put it aside and then worked a little bit more with the Elixir, got more experience and got more of the fundamental pieces of Elixir and then came back to that. And a lot of things started making sense after the second or third attempt, so that's completely normal.
+
+Sundi Myint:
+What I'm curious, Owen, since you, I think, have worked with GenServers, maybe the most amongst the three of us here, is the most often use case that you see for somebody having to write their GenServer, because it doesn't come up very often in an application, is it to manage state? To manage something
+
+Sundi Myint:
+In the state of the application, is that why we normally reach for a gen server?
+
+Owen Bickford:
+Yeah, I think there's a few use cases for gen servers. There's managing state. You can manage state with an agent. So these are all just, I think at a high level, these are all just different types of processes within an Elixir application on the BEAM vm. So you can use an agent, if you're just managing state.
+
+Owen Bickford:
+A gen server also kind of helps you kind of constrain if you want a bottleneck. Sometimes you want a bottleneck, like to serialize messages, make sure they're coming in, in a specific order. So a gen server can help with that. It can also hurt you if you don't want that bottleneck. So that's kind of like an ETZ, not an ETZ case, but a kind of thing to know about gen servers is if you've trying to flow a lot of data through a gen server concurrently, that can kind of slow down your application.
+
+Owen Bickford:
+But yeah, I think owning an ETZ table is how I've used it primarily. So I will start using the Elixir in action example actually. So I wanted to create an ETZ table for memory data storage. And the way that I kind of managed that ETZ table was with the gen server. So whenever the application would start up, it would start up the gen server. The gen server would start the ETS table. And that way they're kind of a linked processes and if something goes wrong, the gen server goes down and it could be restarted by the supervisor.
+
+Sundi Myint:
+Yeah. And I think that something goes wrong piece is kind of key. That's the only time I've ever built one, was for an application that needed to handle state for when the application went down and when it came back. The results of the application state after being down for five to 10 minutes would mean that everything was very out of sync, in terms of we were tracking statuses, so if something was ready or not ready and it wasn't exactly based on time, but it kind of was. So if it went down for 30 minutes or an hour, God forbid an application goes down that long. You had to be able to, when the application came back up, run something to go back through and check to see if things were actually in the state that we said we were in or if they needed to be updated per a few rules.
+
+Sundi Myint:
+And so the best place to add that logic was in a gen server because it happened at the top of the application is how I thought of that. So I actually did it wrong the first time and brought the entire application down because I didn't manage that part of the tree properly because it was right at the top, put it right at the beginning, I don't think anyone really normally is messing with that file that's like right at the top of the application. I can't even remember what it's called. And if you know it, just talk over me.
+
+Owen Bickford:
+Application EX. That one.
+
+Sundi Myint:
+Yeah, that could be it.
+
+Owen Bickford:
+Yeah. So one thing I wanted to say right out as we're kind of starting to get a little bit more into the particulars is you can go a long way without needing to know how gen servers work. If you're primarily working in Phoenix and you're working in controllers and templates and you're kind of more at the front end/full stack, if you're kind of more on that end of things, you're not necessarily going to need to touch a gen server. It is a little bit more of a backend piece of Elixir application.
+
+Owen Bickford:
+But before I get to the next point, does anyone know what gen server stands for? The gen in gen server?
+
+Sundi Myint:
+I just read it, but Kate, I want to hear your guesses.
+
+Kate:
+Do you want me to guess at it?
+
+Sundi Myint:
+Yeah, if you don't know it.
+
+Owen Bickford:
+Just throw one out there.
+
+Sundi Myint:
+Go ahead and just throw one out there.
+
+Kate:
+Generating servers.
+
+Owen Bickford:
+It's so close. I mean...
+
+Kate:
+That is super close.
+
+Kate:
+Is it generation server?
+
+Owen Bickford:
+Yeah. Generic.
+
+Kate:
+Oh, generic. Okay.
+
+Owen Bickford:
+It's like generics, because it's like, so you'll see that in a lot of different Elixir modules, like gen something, like gen state. It's like these are generic pieces and they can be used for very different types of problems.
+
+Owen Bickford:
+So like I said earlier, I used it primarily for setting up ETS tables. Sunday's used it for managing errors and flow control in some ways. But there are at least a dozen different ways you could use a gen server.
+
+Owen Bickford:
+And so just to say that out of the gate, you don't necessarily have to start as a brand new day one Elixir developer knowing anything about gen servers. It's something you can learn about months or years later, depending on the needs of your particular job and what you're doing.
+
+Owen Bickford:
+But yeah. So I'm curious, do you have an idea of what kind of problem you might be working on where you think you might need to open up the gen server docs and maybe start adding a gen server to your application?
+
+Sundi Myint:
+Or maybe the real world example is they told you that you had to do the gen server work. Did they explain why it needed to be a gen server, what the situation would be, that that made sense to reach for that?
+
+Owen Bickford:
+Without divulging proprietary secrets.
+
+Sundi Myint:
+[inaudible 00:17:59].
+
+Kate:
+Yeah, no, I know about that. I don't know how to apply it to our system, to be honest. No, I don't.
+
+Owen Bickford:
+That's totally fine.
+
+Kate:
+I can think of a school project that I did that I might reach for a gen server, but not a real life work example.
+
+Sundi Myint:
+How? That's even more interesting. What? How? What? A school project. Seriously?
+
+Kate:
+Yeah. In school, I went to NC State, it's an engineering college and I was in the engineering college, the computer science program, and we were working with finite state machines and I was supposed to create a ticketing system to someone submits a work order and you track the ticket as it goes through. I would guess that I would need a gen server for that or I could use one, but I could be wrong too. So I don't know. I'd open up the docs and see if I was right.
+
+Owen Bickford:
+Yeah. Yeah. So you could absolutely use a gen server to take in, let's say these are events that are coming through your system, of someone's created a ticket or they've updated a ticket and a gen server could receive those events and then either in it's internal state, like this process memory, they could keep all of that data there or they could, if you start to need more concurrent applications, if you got thousands of users hitting the thing at the same time, then maybe you would move that data into ETS or something a little bit more concurrent so that the calls come through gen server but then they're actually being handed off to ETS. That kind of thing.
+
+Kate:
+Would it create a different process for each user?
+
+Owen Bickford:
+It's generic, so you can set it up to be... So, yeah. If you wanted a gen server, you could have a user's gen server, which would be a bottleneck. So if you had a bunch of users hitting that one gen server, it would kind of force them into a serial, like person A might be blocking person B from their updates if the system was running slowly. Or you might break up your, like you might build a gen server per user. That's another thing you could do.
+
+Owen Bickford:
+So that actually kind of raises I think a point I was struggling to remember that I was going to make. So have you done any work with live view?
+
+Kate:
+Oh, yes.
+
+Owen Bickford:
+Okay. So you've built I'm sure a live view or done some edits on a live view at some point?
+
+Kate:
+Yeah. Earlier when Sunday was talking about how the gen server automatically reconnects or whatever, I was like Socket. That's what I was thinking. I didn't know if that's where you were going.
+
+Owen Bickford:
+So not Socket specifically, but what's interesting is, and I'm going from memory here, but if I remember correctly, live views are essentially a kind of wrapper of a gen server. So when you're writing a live view, a lot of the syntax, the handle error, handle info, all those callbacks you can use, those are very, very similar to what you do with the gen server. So if you think of the live view process, like anyone who connects to your web app and you render this live view, that's a process.
+
+Sundi Myint:
+Those are gen server functions.
+
+Owen Bickford:
+Right. Yeah.
+
+Sundi Myint:
+Handle info and handle call.
+
+Owen Bickford:
+Handle call. Well, handle cast, handle call. Those are some gen server callbacks. I believe, handle information. Handle event may be live view specific.
+
+Sundi Myint:
+I definitely don't have a book in front of me. You see nothing. There's nothing here.
+
+Owen Bickford:
+Right. And I've got the docs open. So yeah, I always keep the docs open so I'm trying to sound smart about something. But, yeah.
+
+Sundi Myint:
+You heard it here first folks.
+
+Owen Bickford:
+The docs are always open. Yeah. So I think handle event is specific to Live View, but you'll see handle cast, handle call, handle information. Those are very similar to things you do within a live view. So that to me, once I had worked with live view and then I was trying to understand gen servers, everything made a lot more sense because writing live view code is a lot like writing gen server code in some ways.
+
+Kate:
+Okay. But where is the callback coming from? When you're on live view, you're using handle info or handle event. Handle event is, like I use that with Pub/Sub. Or handle information, something is coming from the web. Where does the callback come from with a gen server?
+
+Owen Bickford:
+So callbacks in Elixir are defined by behavior. So we're going to throw a lot of words here. So it's okay if, like it took me forever to understand some of these words anyway. So anytime you're saying use phoenix.liveview at the top of your live view module, that's kind of implicitly using something called a behavior. So if you were to look at the live view source code, you would see @behaviorphoenix.liveview I think. And then you'll see at callback, handle info and then it describes what types of arguments you can pass into a handle info function. So a callback is just kind of another word for function that's kind of prescribed by the behavior you're using without defining the actual implementation. So.
+
+Sundi Myint:
+So for the question of where it comes from, I think it's just that the functions are there out of the box as a part of gen server.
+
+Owen Bickford:
+Yeah. If we're talking about gen server, whenever you say use gen server, those callbacks, handle information, handle cast, handle call, those are coming from the gen server module.
+
+Sundi Myint:
+Yeah. So six callbacks are automatically defined and that includes the handle call, the handle cast, handle info, terminate code change, and then the one that everyone uses when they're actually building a gen server, which is init.
+
+Owen Bickford:
+Right. Yeah.
+
+Kate:
+Okay.
+
+Sundi Myint:
+Good old init.
+
+Owen Bickford:
+Does that make sense?
+
+Kate:
+Kind of. But those six callbacks, when are they called?
+
+Owen Bickford:
+So, you decide...
+
+Kate:
+Like let's start with a init.
+
+Sundi Myint:
+Yeah.
+
+Owen Bickford:
+Yeah. So let's just do with it gen servers, just to keep it out of...
+
+Kate:
+In general. Okay.
+
+Owen Bickford:
+Without conflating live view and gen servers, I'll try to simplify it here. So with gen server, so let's say we're going to write a new, let's say, let's write a ticket in gen server in our mind. Okay. So defmodulektap.tickets. So at the second or third line you're going to have use gen server. And then if you write no more code, Elixir LS is going to tell you you've, like it's going to underline squiggles under gen server because you haven't implemented a couple of required callbacks. So I think the first one would be a init.
+
+Sundi Myint:
+Start link is first.
+
+Owen Bickford:
+Well, yeah, typically you'll implement start link. It's not a required callback though.
+
+Sundi Myint:
+Right.
+
+Owen Bickford:
+So start link, you don't... It's optional. You don't necessarily have to write it, unless you want to override the default behavior. But init would be, I believe it's required. And so...
+
+Sundi Myint:
+I think it's just init.
+
+Owen Bickford:
+Yeah. Init takes one argument and you can use that argument. So it could be a keyword list. It could be a strut. It could be a map. However you want to send data into that tickets gen server, that's the type of data that init would receive whenever it's starting up or initializing is what that stands for.
+
+Owen Bickford:
+So then if you look at the docs for gen server, .init, it shows you that it can accept whatever kind of term as it's argument and then it can return either, like [inaudible 00:25:39], with okay, and the state of the gen server. I can return like a timeout. It can return stop or ignore. There's a couple of different ways it can respond whenever it starts up.
+
+Owen Bickford:
+That's the very first step of starting a gen server, is just writing that init command, and figuring out if you want it to receive data as it's starting up. So you would use that maybe to populate
+
+Owen Bickford:
+... relate, like some example ticket data, or to decide the structure of the... Do you want to use a list for all of your records? Do you want to put things in a map? That kind of thing. So that's your first maybe five minutes of a Genserver, is just running in it, figuring out how you want it to start and what type of data it should receive.
+
+Kate:
+Okay. Does it also store that data?
+
+Owen Bickford:
+Yeah. So it could. You could either kind of ignore the data, just underscore that argument inside of a net. Or, let's say, if it's important data that you want to actually use when on the gen server... So when your application's starting, you would say... Inside of your children you would say Kate's app.tickets comma. Usually you'll see empty lists of... Nothing's being passed in there. So it's giving it it's default in net argument. But then whenever... So if you wanted to pass in some other options from the application module, that's where you'd do it. You would just say Kate's app.tickets. And then inside of that list you might put Kate is cold, true, or whatever. Whatever makes sense there. And then...
+
+Sundi Myint:
+You're saying this because Kate's wearing a hoodie.
+
+Owen Bickford:
+Right?
+
+Sundi Myint:
+Simple but colors.
+
+Kate:
+Thank you. Thank you for recognizing that.
+
+Owen Bickford:
+So I don't want to get bogged down in a net, but that's where whatever type of data you want that Genserver to require on startup, that's where you would pass it in. So you might tell which type of struct it needs or options to configure the things. So it runs in a specific way. And then from that point, once your Genserver starts with your application, or even if you start it later on, then it can receive messages. So from any other process you could have a Pubsub that subscribes to Genserver or sends messages to a Genserver. But anytime you want to send messages to your Genserver, you're basically saying either process.send or there's a bunch of different ways to do it.
+
+Owen Bickford:
+But you would do Genserver.call or Genserver.cast and then you would send messages over to Genserver and then... So call... The difference between call and cast is call will... If you have a function that says Genserver.call, it's going to wait for that response from the Genserver, which sometimes you want to wait for that response because you need that result so you can do something with it. Other times, if you're just, say, incrementing a counter and you don't necessarily need to know the new value, then you can do cast and then your application, like your controller or whatever, can keep on moving, doing whatever else it needs to do without waiting for that Genserver to do its math.
+
+Kate:
+So many parts of our code base are starting to make sense to me right now.
+
+Owen Bickford:
+That's awesome.
+
+Sundi Myint:
+Yay. That was the goal.
+
+Sundi Myint:
+So since it's starting to click now, I'm curious if... You kind of made some of these connections because we were talking about how that works with LiveView, and I'm curious if you are using LiveView personally or at work in any projects? Just to give us some context.
+
+Kate:
+I used a lot of LiveView when I was doing my little bootcamp in my mom's basement. That was three months of going through Sophie DeBenedetto book program at Phoenix LiveView. And I've done multiple tickets where I'm working with the LiveView at Simplebet.
+
+Owen Bickford:
+Yeah, I highly, highly, highly recommend her talk and her [inaudible 00:29:34] school article on PubSub and Presence. I watched that a few times because I was struggling to understand those things even before I was tackling GenServer stuff. And just watching those a couple times, hearing her very clear explanations... And clear examples, also, of, here's an example of a user PubSub and Presence, and sending events over PubSub and that kind of thing. A lot of things started clicking whenever I was watching her talk, so...
+
+Kate:
+I need to watch that talk, but she also covers that in her book, which, that book is very solid. Even if you're trying to learn Phoenix, she goes over so much.
+
+Sundi Myint:
+Yeah.
+
+Kate:
+Not just LiveView.
+
+Sundi Myint:
+Is that book, at this point in time, out of beta? Can you physically buy a copy?
+
+Kate:
+Yes.
+
+Sundi Myint:
+Like a physical copy? Or is it updating so fast every day that they can't release a physical copy yet?
+
+Kate:
+No, I think that three months after I started working at Simplebit, I don't remember. They have a physical copy out now I believe. But if you buy it once, if you download it once, you can get every update.
+
+Sundi Myint:
+I just want to know if I can add it to my shelf.
+
+Kate:
+I would love to have that on my shelf.
+
+Sundi Myint:
+Exactly.
+
+Owen Bickford:
+Yeah, that would be a great book to have on display. I think they are going to be doing another big update now that LiveView 0.18 is out.
+
+Sundi Myint:
+Today?
+
+Owen Bickford:
+Phoenix? Yes.
+
+Sundi Myint:
+Today Dave recording 18 came out. 0.18.
+
+Owen Bickford:
+So yeah, they've got a little bit of tweaking to do. I think they were working on it over the summer, but Bruce's on a boat, Sophie's... I think there were just kind of holding, cause there was so much change happening in LiveView with props and adders and...
+
+Sundi Myint:
+It does not look like the first edition physical book has been released yet. So maybe soon, now that we're getting more solid territory.
+
+Owen Bickford:
+Right.
+
+Sundi Myint:
+Sweet.
+
+Owen Bickford:
+So, one thing I was thinking about to illustrate understanding what a Genserver does is how would you test a Genserver?
+
+Sundi Myint:
+Oh yeah. Did you get into any testing when you were kind of going through that project as a starting point? Or where they said you wanted that it should end at?
+
+Kate:
+The project was testing the state management stuff.
+
+Sundi Myint:
+Oh, sorry. So were you writing a Genserver to test the state or were you writing Genservers and then your particular ticket was to test the Genserver?
+
+Kate:
+That was a great question that I will struggle to answer.
+
+Sundi Myint:
+Okay. No, that's fine.
+
+Kate:
+That is where I got introduced to property tests. So if property tests use Genservers, then yes, but I have no idea what I'm talking about, so... I'm just going to be honest.
+
+Owen Bickford:
+Welcome to the party. Yeah, we've all had that day. So the reason I bring up testing is... So at a high level, without thinking about a specific Genserver rule set we'll stick with the ticket example here. But I think the very first things you would test would be... So I've got my Kate's cool dot... Kate's App.tickets Genserver, and I'm going to write a test to, what do I want to know about the... I want to make sure it starts correctly. So if I'm starting it manually, I want to test that, or if I know it's starting with the application, I want to make sure that it's running when the application starts. And then, basically, once it's running, all you're testing is, does the Genserver receive messages? And then does it return responses? Like, if I'm doing a call or if I'm doing a cast, it should return, okay. If I'm sending a call into Genserver, it should return a response.
+
+Owen Bickford:
+And then... So inside of your X unit test, this will be a unit test. So you would say you would have a test that tickets.newticket returns a response. So inside of that test you're going to write tickets.newticket, and you're going to give it a map or whatever attributes, right. And then on another line you're going to write, "assert receive."
+
+Owen Bickford:
+So that's a process assertion. It's going to wait for, so the test is going to wait for this Genserver to send a response and you're going to say, I want the response to look like this. It's probably going to be a twofold that says no reply with the new ticket, or maybe a list of tickets or whatever. And then you can either allow it to wait up to 100 milliseconds, which is the default, or you can allow it to wait a little bit longer, which might slow your test down, but it might fix a broken test there. So that's kind of what I had in mind of... That's kind of how you would see... Is your Genserver doing what it's supposed to do? Is it starting correctly, is it sending the correct responses back? And you do that with assert receive.
+
+Sundi Myint:
+Or you could do what I did, which is just put it where it doesn't... the Genserver, you're right, doesn't work. Put it in your supervision tree and just watch it all implode.
+
+Kate:
+Yeah.
+
+Owen Bickford:
+Implosion driven development.
+
+Sundi Myint:
+Oh my god. Oh, point here first.
+
+Kate:
+So, one thing that Sundi said in the beginning that was great about Genservers is that if they die on accident, they reboot back up. Excuse my terminology, I know my jargon isn't correct, but could you test that?
+
+Sundi Myint:
+Can you test that? That's a fair question.
+
+Kate:
+In a magical world you could, but I don't know if this is that world.
+
+Owen Bickford:
+Let's start with the example where, let's say your ticket's Genserver needs to start with your application. In that case, inside of your application EX file, you're going to have a list of children that's always there by default. So then you would add a new row that says, it's a two poll that says, Ktab.tickets with that empty list, or whatever data you want to send it for initialization. So whenever the application starts, your ticket's Genserver should come up. And then if you want to test that it restarts after a failing inside of your X Unit test, you'd write another test and then you would say... Refresh my memory here, but I think you can just call Genserver to stop and then you can give it a reason. So you can tell it to stop with a normal reason, which is like,, it'll stop and then it should... I think it'll automatically restart.
+
+Owen Bickford:
+But this actually is a little bit more dependent on how your supervisor is configured. So if your supervisor is supposed to restart the process, which I think is the default behavior, then your test... You would say Genserver.stop my Genserver. And then you might sleep for a second, and then assert that Genserver is back online. So yeah, you would probably do... First you would do Genserver.stop, wait a second, and then do Genserver.whereis where is. And that would kind of tell you that the Genserver started back up again with the new process.
+
+Sundi Myint:
+And for more resources on this particular subject, there is, I just checked, a section in the Testing Elixir book by Jeffrey Matthias and Andrea Leopardi of test... How to test a Genserver. And I think it's a whole chapter of testing OTP, but it might be a section specifically dedicated to Genserver. I know a lot of people have that book, so I just wanted to shout that out there.
+
+Kate:
+Can you say the name of the book one more time?
+
+Sundi Myint:
+Testing Elixir.
+
+Owen Bickford:
+Are they paying you?
+
+Sundi Myint:
+No, but my name is on the back of the book.
+
+Kate:
+How did you manage that?
+
+Sundi Myint:
+I did a review. I did a speed read, which is why I don't remember this exact section very well, but I've been slowly reading it all the way through again, because...
+
+Kate:
+I love testing. It's fun.
+
+Sundi Myint:
+I'm like checking my work. I was that kid in school.
+
+Owen Bickford:
+It's fun when they pass.
+
+Sundi Myint:
+No, I mean, yeah. When it's the test fault, that's not fun. If you wrote the test poorly. When it's your code not working, I love that. I want to see why that's not happening the way I think it is. So, really into testing. Jeffrey asked me to review the book when I found out I was really into testing.
+
+Kate:
+I'm with you, Sundi. I found some test files that were messy and I'm like, I just want to organize these. And so I've been organizing test files and I enjoy it. I love order.
+
+Sundi Myint:
+I love order. Oh my gosh. It makes me want to throw chaos at you somehow, but I don't know how to do that.
+
+Kate:
+Okay, well, I'm in my room and this is the only clean spot in my room. So, there's some things that I'm okay with not order. But when it comes to my test files, I like order.
+
+Sundi Myint:
+All right, well, we'll have to let Jeffrey know you said that. Just generally speaking, I just wanted to get a feel for... We've done a little bit of a deep dive into Genservers today. Do you see yourself using them more in the future? Are there aspects of our conversation today that you can maybe apply to other pieces of Elixir application process for the way you code? I'm just thinking of how we can make that broader as a skillset.
+
+Kate:
+Okay. Am I less scared to use it now? Am I more familiar with it now? Do I feel I can ask questions about it now?
+
+Sundi Myint:
+I love it. That's not what I asked, but I will take it. That is a way better question.
+
+Kate:
+I mean, I'm just trying to translate your question. Answer your question with a question.
+
+Sundi Myint:
+Yes.
+
+Kate:
+But
+
+Sundi Myint:
+Are you less scared of using GenServers now? Let's go.
+
+Kate:
+I'm less timid. I feel like if I was working on a project and I need to know the type of tools I'm going to use, I would know better when to use a GenServer. I feel like I could go and do a project with a GenServer now. I don't think I would've done that before this conversation, but now I'm really interested. So.
+
+Owen Bickford:
+That's awesome.
+
+Kate:
+For me, I noticed that I am more of a verbal learner. I like talking about things with people and then I go do it. I know people who can just read docs after docs and then go do a project and they're totally intrigued but I like having conversations about things and doing projects.
+
+Sundi Myint:
+That's interesting because most people will say that if they're a verbal learner, that they're a visual, they need to watch a video versus just talking about it. So, do you learn better by talking about it?
+
+Kate:
+100%.
+
+Sundi Myint:
+Huh. Okay. That might be a first for me, but no, I totally get that because Owen actually sat there and had to illustrate a fake application off the top of his head. What was it the K Cool app?
+
+Kate:
+Yeah.
+
+Owen Bickford:
+Yeah.
+
+Kate:
+I love that.
+
+Sundi Myint:
+Yeah. You have to like form it. Yeah, you have to form it in your head. Yeah. That's interesting. That's really cool.
+
+Kate:
+Well, how many extroverts like, true extroverts do you know in the programming community? I feel like programmers tend to be introverts. I'm very extroverted.
+
+Sundi Myint:
+Todd. Photo.
+
+Owen Bickford:
+Case and point. I do think people at ElixirConf are maybe a little bit more extroverted than they normally would be.
+
+Sundi Myint:
+Yeah.
+
+Owen Bickford:
+I find myself being a little bit more extroverted around other engineers and developers.
+
+Sundi Myint:
+I am peak extroverted at ElixirConf.
+
+Owen Bickford:
+Right. Yeah. I can't talk about sports or the kind of normy topics necessarily, but talk about, you know...
+
+Kate:
+I'm a sports betting company.
+
+Owen Bickford:
+Right. I can sit back and I'll be the audience for that conversation. I'm really happy to hear that things are maybe clicking a little bit with GenServers. I know it's something that took me, I was writing a lot of Elixir code over the years and then kind of putting off GenServers. You have to do this sometimes you can't learn everything at once. So kind of being selective about what you learn and when you learn it totally makes sense. Otherwise, you kind of get burnt out.
+
+Kate:
+Yeah.
+
+Owen Bickford:
+I think one thing I just wanted to point to before we wrap up GenServer talk is there's a really important section in the docs about when not to use a GenServer. I think the one of the gotchas is people will kind of use it, especially coming from Ruby, you might have a User's GenServer and a ticket's GenServer and a blog article's GenServer for every type of data and that's not how you want to use a GenServer. But I'll let the docs explain that better than I can in the remaining minutes we have.
+
+Sundi Myint:
+Yeah. I just didn't want to let us go without addressing Kate's hot topic. Hot take. That we both moved this year. I didn't know you moved Kate. Talking about managing state.
+
+Kate:
+Yeah well.
+
+Sundi Myint:
+You moved states?
+
+Owen Bickford:
+Right? Managing.
+
+Kate:
+No, I did not move states.
+
+Sundi Myint:
+Oh man, Owen, you're really rubbing off.
+
+Owen Bickford:
+Good. Good pun. You're learning.
+
+Sundi Myint:
+Oh, people are watching me in my evolution in the jokes right on the podcast. Kate, please take it away.
+
+Kate:
+Okay, whoa wait, we just need to stop there. Dad jokes? All right, hold up. Were you guys there for Chris McCord's talk? There's like 40 minutes. There was 40 minutes of tech issues and they started going around the room telling dad jokes.
+
+Sundi Myint:
+35 minutes, not counting. Yeah, I was there. I was there.
+
+Kate:
+Anyway, I had to walk out of the room. I was crying. I was laughing so hard. My team was behind me and I'm sure they're like she's laughing too hard at this. I had to walk out of the room and get myself back together.
+
+Sundi Myint:
+That's so great. I love that.
+
+Kate:
+And I started the dad jokes channel at our work.
+
+Sundi Myint:
+Nice.
+
+Kate:
+That's all I had to say.
+
+Sundi Myint:
+Well, so did you move states or not? To get back to the question.
+
+Kate:
+I didn't.
+
+Sundi Myint:
+Okay.
+
+Kate:
+I lived at my parents' house my whole life and I just moved out on my own for the first time.
+
+Sundi Myint:
+Congratulations.
+
+Kate:
+So I'm five minutes down the road from them. Thank you.
+
+Owen Bickford:
+Wow.
+
+Sundi Myint:
+That [inaudible 00:43:36] life.
+
+Owen Bickford:
+It's a big move.
+
+Kate:
+Yeah. Whole five minutes.
+
+Sundi Myint:
+That's the way to do it. I wouldn't do anything big. Not in these times.
+
+Kate:
+Yeah. Yeah.
+
+Sundi Myint:
+That's awesome. And so you're what? Struggling with over decorating? Under decorating? Because decorating is expensive.
+
+Kate:
+Yeah, I know. And my dad's always telling me, you got to make a good investment into a washer and dryer. You are going to use it for 10 years. I'm like, no.
+
+Sundi Myint:
+Aren't you renting?
+
+Kate:
+Please.
+
+Sundi Myint:
+Please tell me you're renting.
+
+Kate:
+I am renting.
+
+Sundi Myint:
+Okay.
+
+Kate:
+But it didn't come with a washer and dryer, so I had to go get one. And beds and couches. But if you get a solid bed or a solid couch or solid washer and dryer, oh my word. $2,000 on each of those. That's minimum.
+
+Sundi Myint:
+I was told when I first got my first job right out of college, I had interned at a place and then I was talking with all my coworkers, I was about to start there full time. They were like, "Sundi, if you're going to invest in one thing, get a really good mattress. That's where you're going to spend half your life. Don't skimp on the mattress". And I started looking mattress, I was like, "Guys, they're like $2,000". They said, "yeah, don't skim on your mattress". And I was like, okay. That was the worst advice I ever took. When you go to a mattress store and you try out the mattresses and they always seem soft and they're going to be great. Yes, they'll take them back but those things are really heavy. I was stuck with that mattress that was thousands of dollars for years because I couldn't make myself get rid of it. Then when I moved to this house, I had to suddenly furnish this house really quickly and I got a Costco mattress for $300 and it's the best thing I've ever slept on.
+
+Owen Bickford:
+100%. I have a very similar story.
+
+Sundi Myint:
+Just saying. You don't have to get a cheap mattress.
+
+Kate:
+Costco.
+
+Sundi Myint:
+Costco is good quality, but you don't have to spend thousands. They just made me think I had to spend thousands for thousand’s sake. So, my life advice don't spend $2,000 on a mattress.
+
+Kate:
+Thank you. Yes. Costco was where I got my mattresses and I ordered them in. Actually.
+
+Sundi Myint:
+Yeah, that's the only way to do it. I don't think you can go to pick them up usually.
+
+Kate:
+Actually, I picked one up from Costco and then the other one I ordered off of Amazon, but it was the same brand. But yeah, Costco has solid mattresses.
+
+Sundi Myint:
+But definitely just huge congratulations on, well, this is our first time talking to you on the podcast, so congratulations on your job. Congratulations on your new apartment. You did a lightning talk, so congratulations on that. And you also, you were the spokesperson for SimpleBet's Sponsor Talk, so congratulations on that. We just had to get it all out there right here at the end.
+
+Kate:
+Thank you. We actually had someone apply at SimpleBet and they said that my talk was a motivator for them and I was like...
+
+Owen Bickford:
+Wow.
+
+Kate:
+I love that.
+
+Sundi Myint:
+That's the best.
+
+Owen Bickford:
+That's what you want to hear.
+
+Kate:
+I was so happy. Yeah.
+
+Sundi Myint:
+Well, this is your time. Do you have any final plugs or asked of the audience? Are you hiring at SimpleBet? Anything you want to just shout out there?
+
+Owen Bickford:
+As an Elixir influencer as you are.
+
+Sundi Myint:
+Yes.
+
+Kate:
+We are hiring at SimpleBet, so please apply. We have a bunch of positions of open engineering, some on the business side and some on the trading side. We have one other side that I forgot. I was looking at the business page yesterday and I guess as a junior developer, I would just say don't be afraid to ask questions. Ask as many questions as possible, try and figure out the answer on your own first but don't be afraid to ask questions. And please post in public channels.
+
+Sundi Myint:
+Yes.
+
+Kate:
+That's all I got to say.
+
+Sundi Myint:
+And you asked great questions today, so we're all here for the journey and the learning, so thank you, Kate.
+
+Kate:
+Yeah, thank you guys for having me.
+
+Sundi Myint:
+Yeah.
+
+Kate:
+This was a lot of fun.
+
+Sundi Myint:
+Awesome. Well that's it for today's episode of Elixir Wizards. Thanks again to our guest, Kate Rezentes for joining us. I'm Sundi Myint and my co-host is Owen Bickford. Elixir Wizards is produced by Hanger Studios and is brought to you by SmartLogic. Here at SmartLogic we build custom web and mobile software. We work in Elixir, Rails, React, Flutter, and more. Need a piece of custom software built? Hit us up. Don't forget to like, subscribe and leave a review. Your reviews help us reach new listeners and you can find us on Twitter at SmartLogic or join the Elixir Wizards discord. The link is on the podcast page and see you next week for more on parsing the particulars.
+

--- a/podcast/elixir-wizards/transcripts/s9e3-tyleryoung-felt.txt
+++ b/podcast/elixir-wizards/transcripts/s9e3-tyleryoung-felt.txt
@@ -1,0 +1,591 @@
+Sundi Myint:
+Welcome to Elixir Wizards, a podcast brought to you by SmartLogic, a custom web and mobile development shop based in Baltimore. My name is Sundi Myint and I'll be your host. I'm joined by my co-host, Bilal Hankins. The season theme is Parsing the Particulars. Today we are joined by special guest , and we'll be diving into the particulars of Geo-mapping. Hey, Tyler.
+
+Tyler Young:
+Hi. I'm so excited to be here. Love the podcast.
+
+Sundi Myint:
+You're so excited to be here that you're wearing a SmartLogic shirt. Don't think that we weren't going to call that out.
+
+Tyler Young:
+Yeah, I put it on this morning, and I was like, "Oh, this is going to be embarrassing." Then I was like, "Nah, we're going for it."
+
+Sundi Myint:
+Okay.
+
+Tyler Young:
+I got a whole new wardrobe at Elixir Comp.
+
+Sundi Myint:
+Amazing. Bilal, how are you doing today?
+
+Bilal Hankins:
+I'm doing pretty splendid. Just got back in New Orleans these past couple days, and I'm reciting them. But yeah, it's been nice.
+
+Sundi Myint:
+Splendid is a good word. But you had another word the other day for how you were feeling.
+
+Bilal Hankins:
+Oh yeah.
+
+Sundi Myint:
+It was pretty particular.
+
+Bilal Hankins:
+I was feeling very chartreuse in the afternoon. I think that was yesterday.
+
+Sundi Myint:
+Yes.
+
+Bilal Hankins:
+Pretty chartreuse.
+
+Sundi Myint:
+Yes, it was. And then I started looking up chartreuse sweaters, and now that will dominate my ad space for the next two days. Got to love the internet. So Tyler, we are talking about Geo-mapping today. So you're from Felt. You want to give us a round down on what Felt is and your role in it?
+
+Tyler Young:
+Sure, yeah. So, Felt is, we make a web app that lets people make maps, and so this is useful for people doing, maybe you're planning a vacation or a backpacking trip, or maybe you're a real estate developer planning what properties to buy. The use cases are endless. We use Elixir and React, and it's an awesome space and a fun product to work on.
+
+Sundi Myint:
+Cool. How did you find yourself in the map industry, or did you interview for a job for Elixir?
+
+Tyler Young:
+Oh, it was definitely for Elixir.
+
+Sundi Myint:
+Okay.
+
+Tyler Young:
+So, when I left, I worked at a place for about 10 years called, X-Plane. They make a flight simulator, so you're flying your virtual airplane and that sort of thing. And toward the end of my time there I worked on this massive multiplayer game server, and got to choose the tech to ride it in, which is rare, and was a lot of fun. Elixir's what I landed on, and I fell in love with it, and I have not wanted to do anything else ever since.
+
+Sundi Myint:
+Cool. So, mapping was not necessarily the draw, but the Elixir was.
+
+Tyler Young:
+Yeah, exactly. I had done a little bit of stuff with mapping and I knew that I was interested in it. At X-Plane we used GIS stuff for doing the scenery. We would take in a bunch of open straight map data, and turn it into tiles and stuff for loading in the 3D world.
+
+Sundi Myint:
+We should definitely put a pin in that because I want to come back to that. When I was driving near the airport in DC, my GPS suddenly got cute, the trees had fuller leaves on it, it zoomed in like we were in a drone showing me the path to take. But it only did that there around the airport, otherwise it was just a pretty normal GPS.
+
+Tyler Young:
+That's why.
+
+Sundi Myint:
+I was like, "Okay, you love Reagan, fine." Bilal, you really were interested in joining this conversation from a mapping standpoint. You want to tell us what you're interested in learning?
+
+Bilal Hankins:
+Well, just looking at the product, Felt itself, I actually, since I did just take a road trip, and I knew this was coming up, I did play around in Felt, and I really liked just the ability. It seemed very cross collaborative. I could invite more people to collaborate on a map. But I really appreciate just drawing on a map. That was my main thing. It's revolutionary compared to Apple Maps.
+
+Tyler Young:
+When I was interviewing, that was the thing that sold me. So, when I was hired, they only had the basics of the drawing feature built out. But the CTO did a five minute demo of drawing, and I was like, "Where has this been all my life?"
+
+Bilal Hankins:
+Right.
+
+Tyler Young:
+"This is the only way I want to plan vacations and stuff from now on."
+
+Sundi Myint:
+That's awesome. Is that what you used, Tyler? I know I saw on Twitter that you hadn't mapped out. Bruce Tate from Groxio is doing the Great Loop where he's sailing from Chattanooga down the Florida coast, up the east coast, through Canada, then through Great Lakes, and then back down of Chattanooga. Did I get that right?
+
+Tyler Young:
+Yeah.
+
+Sundi Myint:
+Is that what you used to draw that out?
+
+Tyler Young:
+Yeah, so I had started, I traced the route with the marker tool based on the drawing that they had on their website. And then I pulled in their, Google maps will give you an export of the points that they had labeled as, this is where we stopped. So, I pulled that from there, Google My Maps, and stuck it in the Felt map.
+
+Sundi Myint:
+Sweet. Yeah, that's when I had this moment where I was like, I need to meet Tyler. I think he's going to Elixir Comp. I'm a big map nerd, and then I just love maps. This is such an interesting conversation to have because I just will, looking at maps, I just looking at them.
+
+Tyler Young:
+Sure.
+
+Sundi Myint:
+When I read any fantasy book, I'm constantly referring to the map at the beginning. They usually have a drawing. We talked about this on the podcast last season, but last season I was reading Wheel of Time. I got through that series really quickly. But it would've been maybe even faster if I had a better map because the series is 20 years old or something. And so the original map that's drawn is just hard to read. They show you rivers, and towns, and portals, and just a bunch of stuff. I always was googling it, and then accidentally spoiling things for myself because I was trying to figure out where they were in relation to other people. So I have since spent a lot of money on a laser cut wood cut map.
+
+Tyler Young:
+That's awesome.
+
+Sundi Myint:
+I've finished reading, but I love this map. It's something that I've always wanted. So, I was really excited to talk to you just from a, I love maps perspective.
+
+Tyler Young:
+Totally. That's awesome.
+
+Sundi Myint:
+All right, cool. Let's just jump right in. So GIS, we threw around that phrase a little bit just now. What does it stand for? Is there any protocol for it? Can you give us a quick TLDR on it? We don't have to go too deep into it. I'm just curious how you use it.
+
+Tyler Young:
+Sure. So, right up front, let me say that I am not the expert here. Everything I know about GIS, I learned on the job and I learned just enough to get the job done. I read the post 'GIS in Action,' which is post GIS, is the plugin for PostGIS. I read that book, and it got me far enough, and that's as much formal education as I've had. So anyway, so GIS, geographic information systems, this is the whole sphere of human inquiry as far as using computers to represent geographic stuff. So for computer nerds like us, stuff like the database representation of a polygon, or a line, or maybe higher level human concepts, this is a route that a person should follow versus these are the points that we actually measured their GPS coordinates, and that sort of thing. So, that's what we're talking about.
+
+Sundi Myint:
+I tried to just quickly Google a history of GIS timeline, and it looks like the earliest history comes up in the 1960s. Then we start going through, Harvard, picks up a lab in 63, and then it goes commercial in 81. So, it's more recent history. But I feel maps have always been around, if you think of evolution of MapQuest to Google Maps, although I heard MapQuest is still an app, it's like an app in use.
+
+Tyler Young:
+Is it really?
+
+Sundi Myint:
+Yes, it's not what it was. So yeah, it's just an interesting concept for those of us who don't know what MapQuest was to some of us back in the day, no one in particular. You used to have to say where you were going to put into the computer, into the website where you started, where you're going, and you would print out the directions to get to that place. Forget traffic, forget roadblocks, forget road changes.
+
+Tyler Young:
+God forbid you take a wrong turn, yeah.
+
+Sundi Myint:
+I absolutely remember back in middle school or something, my mom and I got lost, and we were going to the post office, and we followed the mailman there.
+
+Tyler Young:
+That's awesome. Kids today, they'll never know that joy.
+
+Sundi Myint:
+So, we've talked a little bit about what GIS is. I actually knew what GIS was from college. My history was, I was a computer science major, didn't quite cut it in the math department, and then had to switch to another major. But I had an internship where they said, "You can do whatever, just be any major, and then you're likely to be able to continue coding if you want to keep doing this." And I was like, "Okay, cool." So I went the art route. I considered GIS for a minute because it was the only other information sciences type thing at my school. So, I know you can study it. Can you speak to what somebody who studied GIS in school might actually do in your field, or maybe do you have anyone who works with you who already studied GIS?
+
+Tyler Young:
+Yeah, totally. So, I think of GIS as being a data science engineer with a particular focus on spatial stuff. Maybe somebody with a GIS degree would correct me, but that's how I think of it. We have a whole data team that is focused on taking a big import of data, maybe from open street map, maybe from some other source, and transforming it into something useful. So, they work primarily in Python. They have this big AWS infrastructure to do all this data processing in parallel, and it's a black box for me. They spit out some tiles that we can render on the map, or data sets that we can query, and that's as much as I see from my side.
+
+Sundi Myint:
+We've talked about a few use cases for building out maps, but you wrote one that I'm really interested
+
+Sundi Myint:
+And the current events, mapping out war time kind of things, specifically, you mentioned Ukraine and then planning forest fire responses. Have you seen those kind of use cases for mapping?
+
+Tyler Young:
+We have and we've seen it in Felt. So some of our earliest beta testers were fire department. I want to say it's somewhere in California. I'm going to get the city wrong if I say it. But they basically took... We have these data sets that show historical locations of wildfires and so they can kind of look at that and say, "This is where the wildfires were in 2021, and so here's where we need to focus our efforts for this coming season." And so they can draw on it and they can share it around and that sort of thing.
+
+Tyler Young:
+It's kind of a similar story for mapping current events and stuff. Anytime you see a New York Times map of this is what's going on in the Ukraine war and here's the front, or here's the city that's being attacked and that sort of thing. We want to support doing that sort of thing in Felt. And so there are a couple small news organizations using it now, but we're trying to target some of the bigger names.
+
+Bilal Hankins:
+Wow. I hadn't thought of forest fires, but now that you outlined you like that, Yeah, I can really see how that's a real good use case of this.
+
+Tyler Young:
+Right? Yeah. And compared to maybe having pins on a wall somewhere, it's a lot easier. You can interact with that map from your phone when you're on the site and that sort of thing.
+
+Sundi Myint:
+So does Elixir do anything in particular that really lends towards map making? Are there any specific Elixir features that you use a lot? There's so many features of Elixir I can't even name drop any, but yeah.
+
+Tyler Young:
+Sure. Yeah, I think Ecto is a superpower. It's so flexible for doing even really low level stuff. We want to use a bunch of post GIS queries to say, get a bounding box for a bunch of stuff on your map. And being able to drop down and use that low level stuff is really nice.
+
+Sundi Myint:
+Bounding box is actually a really interesting, since we're deep diving, can you explain a bounding box? Because I have worked with one before, but it was like two years ago and I forgot.
+
+Tyler Young:
+Sure, sure. Sorry. Sometimes I'm so embedded in it, I forget that this is not something other people are dealing with every day. Yeah.
+
+Sundi Myint:
+Yeah. We're deep diving. We're going in.
+
+Tyler Young:
+Yeah. Yeah. So a bounding box, if you imagine you have a dozen polygons that are placed somewhere across the US, let's say. A bounding box would be a square with the west, aligned with the west most edge of the west most coordinate and it's east side is the east most coordinate of all of your elements and so on. So it's like it's a northeast, southwest aligned box that fits all of your stuff. This is useful in our case because the first time that you load the map, we want to show it zoomed out to a place where you can see everything.
+
+Sundi Myint:
+Yeah. A technical consideration, I remember working with boundary boxes or bounding boxes was if you were to consider what is a natural zoomed out state, if you had no address, did you just focus on the US? Or if you do have an address, how far can you zoom out before that data disappears? Are these kind of considerations that you run into?
+
+Tyler Young:
+Sure. Yeah. So the initial state of a new map, we try to geo locate your IP and we pick a zoom level that we hope will capture the city, whatever city you're in. So for me, I think it actually focuses 40 miles north of me or something. That's kind of funny.
+
+Sundi Myint:
+So you said Ecto was a superpower. What else from Elixir?
+
+Tyler Young:
+Well, the library support is good, and I'll put a little asterisk there because there are libraries for dealing with GeoJSON, which is a very common interchange format. There are more obscure ones like GPX. GPX is basically the interchange format for GPS data. Similarly, there's support for KMLs. KML is Google's file format that they use for I think all kinds of geo data.
+
+Tyler Young:
+The reason I put a little asterisk there is because ultimately at Felt we wanted to support everything. If you could name a geo data file, we wanted to be able to support it. And so kind of bundling together these disparate libraries wasn't cutting it for us. And so we shell out to a program called GDAL, G-D-A-L and GDAL supports hundreds or thousands of file formats and can transform it all into GeoJSON for us. So I was a little sad to lose the built in Elixir support, but it's pretty comprehensive.
+
+Tyler Young:
+The other thing I will say is the library support for post processing data is really good. So you can represent a latitude and longitude as a two pull of two floats and do all kinds of manipulation on that. We had an interesting problem a while back where per the GeoJSON spec, a polygon is supposed to be wound in a counterclockwise direction. Basically, if you look at the list of points, they should go counterclockwise from the start. And we had some data in the database that was not wound the correct direction and that turned into a geometry problem. Basically, you try to find the area of the shape and if it winds up being positive, it's counterclockwise. And if it's negative, it's not counterclockwise wound and we need to reverse it.
+
+Tyler Young:
+Elixir is like people give it so much trouble for, it's not good for number crunching and stuff, and for our case, if you've got 10,000 elements on a map, it's plenty fast enough to do that analysis.
+
+Bilal Hankins:
+It seems like something that like Elixir would be built for.
+
+Tyler Young:
+Sure. I mean, when you talk about if you've got hundreds or thousands of requests coming in a second, it doesn't really matter if it takes 10 milliseconds to do that analysis or not. The fact that you can serve all of those at the same time is what's important.
+
+Sundi Myint:
+So not to talk about competitors, or I don't even know if you call these competitors, but there are other map companies out there who use other technologies. I guess the first question is, do you ever have to interface with the other map companies? But secondary to that, what is the common language for mapping, if that's a thing?
+
+Tyler Young:
+I mean, JavaScript has taken over the world, so I know there's a lot of mapping applications that use node on the back end and that sort of thing. I mean, I think the most common thing to do is if you just need a website with one map that shows your location or something, what people do is they embed the Google Maps API and they don't have a backend at all. For us, having Elixir on the backend, it gives us such speed of development and the performance is great, the scalability is great. The story for using that as a wrap around post greisen and post GIS is phenomenal.
+
+Bilal Hankins:
+So how does Felt fit in to this ecosystem of all the other maps that I guess people are more commonly familiar with?
+
+Tyler Young:
+Yeah, so I think what you're getting at is do we have an API that people can use? And the answer is unfortunately no. Am I getting that right?
+
+Bilal Hankins:
+Just, yeah, I suppose just how you guys see yourself just amongst these other map companies as well.
+
+Tyler Young:
+Sure, sure. So one of the things we talk about is the shadow of Esri. So Esri, E-S-R-I, is the... It's like the professional GIS tool and it has a learning curve unlike anything I've ever seen. If you've tried to pick up Blender or Photoshop or something, it's like that.
+
+Bilal Hankins:
+Oh, okay.
+
+Tyler Young:
+And it's super powerful and if you studied GIS for four years in college, I'm sure that you're totally comfortable with that. But what we've seen is that companies who are using geospatial data in the real world, they have one cartographer on staff. If you're a small city government or something, everybody is inundating that one person with requests. I need a map for the bus line, I need a map for the subway, I need a map for this development. And that person just has limited time. And so the stuff you see is maybe somebody's using PowerPoint, they take a screenshot of a map and they draw on the map and they're like, "Here, we'll use this in the brochure" or whatever, or stick it on the website. We're trying to unlock use cases for those people who maybe they don't have a GIS degree or maybe they do and they just want something's fast. That's who we're aiming for.
+
+Bilal Hankins:
+Yeah, I can definitely see that. And this is definitely useful for me on my road trip, I'll tell you that.
+
+Tyler Young:
+Sure, sure.
+
+Sundi Myint:
+Baal is going cross country for just kind of any reason, but also to, I mean, didn't you go for your sewing machines?
+
+Bilal Hankins:
+Yeah, I drove from Vegas to Amarillo, Texas for two industrial sewing machines. My babies.
+
+Tyler Young:
+Wow. So do you sew? What do you sew?
+
+Sundi Myint:
+Yeah. Baal. This is Baal's first episode as a co-host everyone. We got to introduce Baal.
+
+Bilal Hankins:
+Yeah. So before transitioning into software engineering, I had my own clothing brand and I also helped out with manufacturing and design for a lot of local brands in New Orleans as well. It was pretty cool. I was in high school and I got the chance to go to what, Paris Fashion Week, Milan Fashion Week, and a bunch of trade shows in Europe, which was very eyeopening.
+
+Tyler Young:
+That's awesome. Wow.
+
+Sundi Myint:
+Oops. We've got some cool people here at Smartwatch.
+
+Bilal Hankins:
+We've got some cool people.
+
+Sundi Myint:
+Just putting it out there.
+
+Tyler Young:
+Love it.
+
+Sundi Myint:
+Yeah, so Baal's concept of yeah, I'm just going to skip over to Texas to get my sewing machines and I'm sitting here hyperventilating over having to go 15 minutes down the road because I've never gone that direction before.
+
+Bilal Hankins:
+That's why I was excited to be on this episode.
+
+Sundi Myint:
+Yeah.
+
+Tyler Young:
+Too cool.
+
+Sundi Myint:
+I think the other experience I have with, so in, I was originally in DC, like most of my career life was while I was living in DC and the big map company there is Mapbox and I think it was Node. I never actually worked there. A bunch of my friends did. And I remember their lobby, because they used to host a lot of meetups and different kind of get togethers and stuff. Their lobby has this dot map. It looks like a scatter plot like you'd
+
+Sundi Myint:
+... see in a math class, but then when you step back, I almost said zoom out, but when you step back from it, you can tell it's D.C. It must be points for some... I don't know what the points were, but as an art major and a nerd and a math nerd and somebody just waiting for the meetup to start was just staring at that like, "This is the coolest thing I've ever seen."
+
+Tyler Young:
+That's pretty awesome. Wow.
+
+Sundi Myint:
+And I know some people I know had used Leaflet for some... I think it was a more accessible tier to use. It wasn't as expensive or something. It's always interesting when you talk about integrating with these map companies that tend to have the expensive kind of tiers and whatnot. Do you think the speaking of the API that you're looking towards building something that people can use?
+
+Tyler Young:
+Yeah, so right now the story for using a Felt map on another site is like you create in Felt and then you can embed it, stick an iframe wherever you want. I don't know that we'll ever be a developer-focused company in the way that Mapbox is. Mapbox makes all their money from developers programmatically creating maps, but we do want to support more of those use cases, and so we have a number of people in our Felt Slack that we're getting ideas from for like, "What is it that you want to build with an API?" But yeah, that's still a work in progress.
+
+Sundi Myint:
+So I guess the ultimate dream is, like you said, right now the developers reach for a Google Map API, kind of quick integration to do anything that has a quick map. But I haven't had to do this integration myself, but I do recall that feeling of dread when it happens, turning that API on is really hard. Can you speak to that a little better? You're nodding like you know what I'm talking about, and I don't know what I'm talking about.
+
+Tyler Young:
+Oh my gosh. I've only done it a couple times, but for me, anytime I have to go into the Google Cloud services backend, I'm so overwhelmed and I want to get out as soon as I possibly can. For Felt, we have kind of taken the route of self-hosting a ton of the infrastructure. So rather than going to Mapbox to get the tiles that draw a mappy looking background on your map, we are self-hosting that and we're looking at self-hosting even more data stuff in the future. So yeah, we're kind of spared that integration.
+
+Sundi Myint:
+So my point there was the dream could possibly be to make Phoenix Map components that we can just drop into our applications. Is that something that you've talked about?
+
+Tyler Young:
+If I were in charge of the roadmap and didn't have to worry about keeping the company afloat, yes, we would totally be doing that. There have been talks about doing the map live book component. I think that'd be really cool. I mean we just don't have the bandwidth right now, but yeah, someday that'd be pretty sweet.
+
+Sundi Myint:
+Do you think you'd consider open sourcing it so people would help you?
+
+Tyler Young:
+I don't know. I would have to talk the CTO for it.
+
+Sundi Myint:
+Okay. You talked to him. Cause I feel like Bilal right here with all that free time between sewing and developing and now podcasting...
+
+Bilal Hankins:
+I could be contributing.
+
+Sundi Myint:
+We're always trying to strive for more open source projects out there. So...
+
+Tyler Young:
+Totally.
+
+Sundi Myint:
+Just going to plug that and drop in Phoenix components for maps would be sweet. But yes to, I've always been advocating for more live books to play around with because then we could learn a system or a technology better and I've never really understood too much about programming with maps. So that would be really fun to say. Also, I hope somebody's playing a drinking game right now. They're drinking every time they care the word map.
+
+Tyler Young:
+No, that's the beauty of working at this company. I was doing a functional data transformation, a map over a map, the data structure, to produce a map.
+
+Sundi Myint:
+oh no, you must run into the keyword error all the time?
+
+Tyler Young:
+Oh yeah. So...
+
+Sundi Myint:
+How do you get over that?
+
+Tyler Young:
+In the backend we don't actually call it a map. The thing that we are producing, we chose arbitrarily from another language. We call it a carta. Just so that you can... Just so that there's a little less confusion.
+
+Sundi Myint:
+Okay. There we go. Yeah. Bilal, you and I are... Yeah, we've been working on the same project. So do you remember what was a keyword recently? And I couldn't get over it because I couldn't... Think it might have been state or status or...
+
+Bilal Hankins:
+I know event, that might have been one that I was dealing with. Because I feel like that keyword always mess me up. But Tyler, I thought you were going to say you guys play a drinking game.
+
+Sundi Myint:
+Yeah. I thought you were going to say you're just drunk all the time.
+
+Bilal Hankins:
+And I was like, that's what makes working at Felt fun. I was like wow...
+
+Tyler Young:
+It's not that kind of startup.
+
+Sundi Myint:
+Oh that's a good one. Oh my gosh. Oh man. I didn't even think about the map situation. Like the struck map situation.
+
+Tyler Young:
+Yeah, absolutely.
+
+Sundi Myint:
+Oh that's a fun one. That's a fun thing to think about for sure. Okay, so I want to reroute us a little bit because we completely just skyrocketed past your hot take. Tell us about your hot take.
+
+Tyler Young:
+My unpopular opinion is that I am not a fan of managed services in general. I miss the days when we had a VPS or a co-located physical bare metal server that you know would stand up and had application on and you were responsible for updates and keeping the database alive and all that stuff. I feel like what I get out of managed services is just not worth the added complexity.
+
+Sundi Myint:
+And could you name drop a few? I'm trying to connect these dots here. What do you mean by managed service? What is an example of them?
+
+Tyler Young:
+Well certainly anything on AWS.
+
+Sundi Myint:
+Okay. Okay. So the DevOp side of things. You miss...
+
+Tyler Young:
+Yeah.
+
+Sundi Myint:
+The simpler DevOps days.
+
+Tyler Young:
+Yeah, I miss pseudo doing in to run app to get update or whatever as needed. And you know can do that with Bluegreen deploys, right? You've got two servers and one's staging and one's fraud and then you switch them. I like that setup a lot and I miss it.
+
+Sundi Myint:
+That is absolutely a hot take and I hope everyone has a nice friendly discussion about it on the discord that we have.
+
+Bilal Hankins:
+I'm with you there, Tyler. I used to host a 200 people server of Minecraft on my home MacBook and it was like a 2010 MacBook and...
+
+Tyler Young:
+That's awesome.
+
+Bilal Hankins:
+Port forwarding from my MacBook and leaving it running 24 hours cause the people in my Minecraft server had to play hunger Games.
+
+Tyler Young:
+That's fantastic.
+
+Sundi Myint:
+Tyler, you're not just experiencing this for the first time. We experience this every day. Bilal comes with a nugget every single day. I'm crying. Oh my god.
+
+Bilal Hankins:
+Just to make you guys feel a little...
+
+Sundi Myint:
+That's not even a make us feel old thing that's like a... 200 people? How old were you?
+
+Bilal Hankins:
+So honestly, I think this was third grade.
+
+Tyler Young:
+Oh my gosh.
+
+Bilal Hankins:
+I was building Japanese architecture houses in Minecraft. I really like Minecraft. It's a very beneficial learning tool.
+
+Sundi Myint:
+Yeah, no I did the same thing in the Sims. I liked looking at different... Actually Japanese architecture. Yeah, I've made Japanese architected styled homes in the Sims before, but that was buying a game and logging into it. Absolutely not creating a server to host 200 people.
+
+Bilal Hankins:
+Yeah, I remember reading a whole bunch of guides about port forwarding and DNS servers and I was what, nine years old?
+
+Sundi Myint:
+Bilal, we missed this part when we asked how you got into tech, you started somewhere else when we asked you this question last time.
+
+Bilal Hankins:
+If we really want to go farther, I was making custom C++ avatars and I think I was like five or six.
+
+Tyler Young:
+Oh my gosh.
+
+Sundi Myint:
+Okay.
+
+Bilal Hankins:
+But I couldn't do any of that stuff now. Maybe port forwarding, but looking back on that, that is pretty cool.
+
+Sundi Myint:
+I'm just spiraling live here guys. Okay. While I compose myself. Bilal, you have any other... You want to take the wheel? You ask Tyler a question now. I'm just going to go die in the corner.
+
+Bilal Hankins:
+Well I guess are there any particular advantages to using Elixir when it comes to building maps? I mean I feel like we might have touched on a few.
+
+Tyler Young:
+I'm always sad because when people hear that we're using Elixir and Phoenix, their first question is always like, is it Live View on the front end? And I'm always like, nah, it's React.
+
+Bilal Hankins:
+I was going to ask that.
+
+Tyler Young:
+Yeah. Yeah. So in the same way that Elixir is fantastic for any sort of web app backend that you would want, a lot of the stuff we do is crud and Elixir is really good at that. But we kind of made the decision early on that we didn't want to bet the whole company on LiveView being the right choice for a really highly interactive front end that's collaborative across 30 people. Yeah. So it's React in the front end I guess actually multiplayer the idea of having a bunch of people connected to the same map and everybody editing and seeing everybody else's edits. That is something that other languages have kind of imitated the Phoenix channels model. But yeah, Channels is so great. We have one channel for a map and we push messages onto it when edits happen and everybody just gets the updates and it works so well, so seamlessly.
+
+Sundi Myint:
+This is not, I promise this is not a loaded question, I'm prefacing with that. Do you think LiveView would do it better or do you think React is like specially tuned to do what you need on the front end?
+
+Tyler Young:
+I don't know if LiveView would do it better. I think you could do it in LiveView. Personally having experienced a front end written in Elm,
+
+Tyler Young:
+I do think if we had gone Elm from the beginning, I think our rate of shipping features and the reliability of the app would be slightly improved. But the one thing that React has going for it is that you can find a ton of people who have made highly interactive apps in it. It's very easy to hire for.
+
+Sundi Myint:
+And, information. Definitely easy to search something. 17,000 people have had the same problem. Yeah, it's fair.
+
+Tyler Young:
+And you'll find a lot of bad advice out there on it. But yeah, there'll always be something in the search results.
+
+Sundi Myint:
+But there is something to be said for the bad advice, because I think we don't talk about this enough, is that my favorite way to attack any problem is just to do it in the first way I think of it, even if it's bad. Even if I know it's bad, let me just do it. And then two weeks ago, I was writing a lot of Ecto queries, or maybe it was last week, and my sense of time is completely warped. I think it was last week. I wrote a bunch of Ecto queries, been a while since I touched them. And I just wrote a bunch of queries, like five different queries that I was pretty sure wouldn't return anything. And it helped me get to the final query, just writing it poorly a few times.
+
+Tyler Young:
+Totally. The story that I've heard is a person, they're trying to go out to lunch with their office, and nobody wants to make a decision. And so they sit there and they're like, "Where should we go?" And nobody suggests anything. And so finally the person says, "Let's go to McDonald's." And everybody in the whole room says, "No, oh God, not McDonald's." And so suddenly they can come up with something better than that, and eventually they all settle on something that they all will actually like. And so, I've heard it called the McDonald's option. So if you don't know where to start, you start with the McDonald's option and you can at least improve it from there. Or maybe that's good enough and you ship it like that.
+
+Bilal Hankins:
+I've never heard of that, but I'm glad I have that term. The McDonald's option.
+
+Tyler Young:
+I use that all the time. Well, the McDonald's option is, do it this way.
+
+Sundi Myint:
+McDonald's must love that.
+
+Tyler Young:
+I know, right?
+
+Sundi Myint:
+They know what they are.
+
+Tyler Young:
+There's no such thing as bad publicity.
+
+Sundi Myint:
+Yeah. Sweet. So you and Jason, were at ElixirConf? Was anyone else from Felt at ElixirConf this past?
+
+Tyler Young:
+No, just me and Jason Axelson. We are currently two thirds of the back end team. So yeah, folks might know Jason Axelson from contributing to hundreds of open source projects. I have no idea how he does it.
+
+Sundi Myint:
+ElixirLS being one of the biggest ones. You mean they don't know Jason Axelson from his episode on the Elixir Wizards Podcast?
+
+Tyler Young:
+Oh yes.
+
+Sundi Myint:
+I think of Jason every time it says my ElixirLS is out of date, and I'm like, "Ah, you folks are working hard over here making me update all these."
+
+Tyler Young:
+I think he would want me to quickly point out that he is less involved with ElixirLS now than he has been, but he still does a ton of open source on the side. He doesn't have kids.
+
+Sundi Myint:
+But Hawaii, though.
+
+Tyler Young:
+Yeah, exactly.
+
+Sundi Myint:
+Now that would be a place to map out, just to bring it back.
+
+Tyler Young:
+We have a ton of trail data from Hawaii, I think partially for Jason.
+
+Sundi Myint:
+Oh, I thought you were going to say Jason went out there hiking to grab the trail data.
+
+Tyler Young:
+Oh, I wish.
+
+Sundi Myint:
+Oh, that would be cool. That'd be a cool way to ask somebody to be involved. "Oh yeah, for work today I hiked."
+
+Tyler Young:
+Right.
+
+Sundi Myint:
+So what is, if at all, Felt's involvement with the Elixir community? Do you just like being involved because you two like being involved or does Felt have any kind of hiring? Are you hiring and you're going out there to find more people, or what's the situation there?
+
+Tyler Young:
+Yeah, we are definitely hiring. Please come work with me if you want to do Elixir and a little bit of React.
+
+Sundi Myint:
+Not too much they promise.
+
+Tyler Young:
+Yeah, right, right. There are definitely people in Elixir land with a JavaScript allergy. That's okay.
+
+Sundi Myint:
+Allergy, that is the best way to put it. Oh my God.
+
+Bilal Hankins:
+Yeah. We have a couple people with some JavaScript allergies.
+
+Sundi Myint:
+I'm suffering from the JavaScript allergy right now. Oh my gosh.
+
+Tyler Young:
+I am not a JavaScript fan. TypeScript is really cool if you are interested in Type systems at all. It's kind of a shame that it's built on top of JavaScript is what I tell people.
+
+Bilal Hankins:
+Yeah. I like TypeScript. In my boot camp, we learned, or a final project had to be in TypeScript and it definitely, I don't like JavaScript now compared to TypeScript.
+
+Tyler Young:
+Sure, yeah. That was part of what motivated me to take the job was that I didn't know anything about React or TypeScript and it was like, kind of the whole world is moving that direction, so I should probably figure this out at least a little bit.
+
+Sundi Myint:
+Yeah, at least a little bit. But I'm going to use that phrase forevermore, that and the McDonald's option.
+
+Tyler Young:
+There we go.
+
+Sundi Myint:
+I'm just going to add that to the vocabulary there. For our kind of fun outro question before we wrap up here, do you have a favorite map? I've talked about my favorite map. Do you have a favorite map?
+
+Tyler Young:
+So I made a map of this trip that my wife and I did in Southeastern Alaska. It's called the Golden Circle. I almost said The Great Loop. That's the other one. So the Golden Circle is, it goes through Juno and all these very scenic places and there are some plane flights and some beautiful drives through the mountains and stuff. Yeah, it was a heck of a vacation. And the map is really cool because I've embedded video that I took and images and links to some of the cool attractions and stuff. That's definitely my favorite one.
+
+Sundi Myint:
+Awesome. Well again, thank you Tyler for being here. Do you have any final plugs or asks for the audience? Any social media where people can find you or how they can support your future open source projects?
+
+Tyler Young:
+Sure. So I'm Tyler A. Young on Twitter because there are too many Tyler Youngs in the world. If you want to apply, we would love to get some Elixir and React developers. It's felt.com/careers.
+
+Sundi Myint:
+Awesome. Well that's it for today's episode of Elixir Wizards. Thanks again to our guest, Tyler Young for joining us. I'm Sundi Myint and my co-host is Bilal Hankins. Elixir Wizards is produced by Hanger Studios and is brought to you by SmartLogic. Here at SmartLogic we build custom web and mobile software. We work in Elixir Rails, React, Flutter, and more. Need a PC that's custom software built? Hit us up. Don't forget to like, subscribe, and leave a review. Your reviews help us reach new listeners. You can find us on Twitter at SmartLogic or join the Elixir Wizards Discord. The link is on the podcast page. And see you next week for more on parsing the particulars.
+


### PR DESCRIPTION
Fireside RSS stopped putting individual episode art in each item in the feed, so the script was breaking. This uses the channel (postcast) album art as the episode art for now, the page looks poor with all the same cover art over and over, but it at least works. I also added the section for season 9 and the quick links to jump down the page for more recent seasons that had been missed.

We can revisit to see if something can be changed in Fireside, or was changed in fireside, to cause this issue. If the image comes back, the script should pick it up still.