### PR TITLE
add blog link to header

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -15,6 +15,7 @@
         <li class="header__menu-item"><a href="/method">Method</a></li>
         <li class="header__menu-item"><a href="/case-studies">Case Studies</a></li>
         <li class="header__menu-item"><a href="/podcast/elixir-wizards">Podcast</a></li>
+        <li class="header__menu-item"><a href="/blog">Blog</a></li>
         <li class="header__menu-item"><a class="btn" href="/contact">Let's Get Started</a></li>
       </ul>
     </nav>


### PR DESCRIPTION
To improve visibility, a `Blog` link has been added to the header.