### PR TITLE
313 video audio embeds not responsive

### DIFF
--- a/_sass/pages/podcast.scss
+++ b/_sass/pages/podcast.scss
@@ -180,15 +180,11 @@
   }
 }
 .podcast-video-container, .podcast-audio-container {
+  height: 0;
+  padding-bottom: 56.25%;
+  padding-top: 30px;
   position: relative;
   overflow: hidden;
-  width: 100%;
-
-  &:after {
-    display: block;
-    content: "";
-    padding-top: 56.25%;
-  }
 
   iframe {
     position: absolute;
@@ -196,5 +192,15 @@
     left: 0;
     width: 100%;
     height: 100%;
+  }
+}
+.podcast-audio-container {
+  padding-bottom: 25.6%;
+  padding-top: 5vw;
+}
+// The fireside embed aspect ratio is non-constant
+@media screen and (max-width: 445px) {
+  .podcast-audio-container {
+    padding-top: 10vw;
   }
 }

--- a/_sass/pages/podcast.scss
+++ b/_sass/pages/podcast.scss
@@ -179,3 +179,22 @@
     text-align: center;
   }
 }
+.podcast-video-container, .podcast-audio-container {
+  position: relative;
+  overflow: hidden;
+  width: 100%;
+
+  &:after {
+    display: block;
+    content: "";
+    padding-top: 56.25%;
+  }
+
+  iframe {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+  }
+}

--- a/podcast/elixir-wizards/index.html
+++ b/podcast/elixir-wizards/index.html
@@ -38,13 +38,17 @@ include_rss: true
     <!-- overview -->
     <section class="section content-block podcast">
       <p><em> Watch our latest episode:</em></p>
-      <iframe id="latestVideoEmbed" width="960" height="540" frameborder="0" allowfullscreen></iframe>
+      <div class="podcast-video-container">
+        <iframe id="latestVideoEmbed" width="960" height="540" frameborder="0" allowfullscreen></iframe>
+      </div>
 
       <br/>
       <br/>
       <p><em> Listen to our latest episode:</em></p>
 
-      <iframe style="margin-bottom:20px" src="https://player.fireside.fm/v2/IAs5ixts/latest?theme=dark" width="960" height="200" frameborder="0" scrolling="no"></iframe>
+      <div class="podcast-audio-container">
+        <iframe style="margin-bottom:20px" src="https://player.fireside.fm/v2/IAs5ixts/latest?theme=dark" width="960" height="200" frameborder="0" scrolling="no"></iframe>
+      </div>
 
       <p>Elixir Wizards is an interview-format podcast, focused on engineers who use the Elixir programming language.
         Initially launched in early 2019, each season focuses on a specific topic or topics, with each interview focusing on the guest's experience and opinions on the topic. Our hosts as of Season Eleven are Owen Bickford, Dan Ivovich, and Sundi Myint.</p>

--- a/podcast/elixir-wizards/season-eight.html
+++ b/podcast/elixir-wizards/season-eight.html
@@ -29,7 +29,9 @@ include_rss: true
   <!-- main body content -->
   <div class="content-page-wrapper">
     <section class="section content-block podcast" id="s8">
-      <iframe width="960" height="540" src="https://www.youtube.com/embed/videoseries?si=oDyEOFZxL-U8t0iX&amp;list=PLTDLmInI9YaAPlvMd-RDp6LWFjI67wOGN" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+      <div class="podcast-video-container">
+        <iframe width="960" height="540" src="https://www.youtube.com/embed/videoseries?si=oDyEOFZxL-U8t0iX&amp;list=PLTDLmInI9YaAPlvMd-RDp6LWFjI67wOGN" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+      </div>
       {% include old-season-episodes.html season='Season 8' %}
     </section>
 

--- a/podcast/elixir-wizards/season-eleven.html
+++ b/podcast/elixir-wizards/season-eleven.html
@@ -42,7 +42,9 @@ include_rss: true
   <!-- main body content -->
   <div class="content-page-wrapper">
     <section class="section content-block podcast" id="s11">
-      <iframe width="960" height="540" src="https://www.youtube.com/embed/videoseries?si=k-N4VmHlXAuPH_jp&amp;list=PLTDLmInI9YaDbrMh8gvb--Lxs90nyVQT0" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+      <div class="podcast-video-container">
+        <iframe width="960" height="540" src="https://www.youtube.com/embed/videoseries?si=k-N4VmHlXAuPH_jp&amp;list=PLTDLmInI9YaDbrMh8gvb--Lxs90nyVQT0" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+      </div>
       {% include old-season-episodes.html season='Season 11' %}
     </section>
 

--- a/podcast/elixir-wizards/season-five.html
+++ b/podcast/elixir-wizards/season-five.html
@@ -29,8 +29,12 @@ include_rss: true
   <!-- main body content -->
   <div class="content-page-wrapper">
     <section class="section content-block podcast" id="s5">
-      <iframe src="https://player.fireside.fm/v2/IAs5ixts+5GV4qQWP?theme=dark" width="960" height="200" frameborder="0" scrolling="no"></iframe>
-      <iframe width="960" height="540" src="https://www.youtube.com/embed/videoseries?si=a0CFM0yK9nj3Tzwc&amp;list=PLTDLmInI9YaAXVIf2ceCsotRhKYjxaiZq" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+      <div class="podcast-audio-container">
+        <iframe src="https://player.fireside.fm/v2/IAs5ixts+5GV4qQWP?theme=dark" frameborder="0" scrolling="no"></iframe>
+      </div>
+      <div class="podcast-video-container">
+        <iframe width="960" height="540" src="https://www.youtube.com/embed/videoseries?si=a0CFM0yK9nj3Tzwc&amp;list=PLTDLmInI9YaAXVIf2ceCsotRhKYjxaiZq" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+      </div>
       <blockquote cite="/podcast/elixir-wizards/s5e8-nowack-heinz/">
         You don't have to convince your company to make a wholesale switch to Elixir if you can just deploy something — something that adds value and you can get people using that. You can make an incremental change.</blockquote> <cite>— Shaun Robinson in <a href="/podcast/elixir-wizards/s5e13-robinson-billups/">S5E13 on Using Elixir to Empower Online Learning</a></cite>
       {% include old-season-episodes.html season='Season 5' %}

--- a/podcast/elixir-wizards/season-four.html
+++ b/podcast/elixir-wizards/season-four.html
@@ -28,8 +28,12 @@ include_rss: true
   <!-- main body content -->
   <div class="content-page-wrapper">
     <section class="section content-block podcast" id="s4">
-      <iframe src="https://player.fireside.fm/v2/IAs5ixts+_-HB_kh-?theme=dark" width="960" height="200" frameborder="0" scrolling="no"></iframe>
-      <iframe width="960" height="540" src="https://www.youtube.com/embed/videoseries?si=b4nYiuX_zaEQy-kR&amp;list=PLTDLmInI9YaAJHCDPbqZVGBg2FthJQChK" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+      <div class="podcast-audio-container">
+        <iframe src="https://player.fireside.fm/v2/IAs5ixts+_-HB_kh-?theme=dark" width="960" height="200" frameborder="0" scrolling="no"></iframe>
+      </div>
+      <div class="podcast-video-container">
+        <iframe width="960" height="540" src="https://www.youtube.com/embed/videoseries?si=b4nYiuX_zaEQy-kR&amp;list=PLTDLmInI9YaAJHCDPbqZVGBg2FthJQChK" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+      </div>
       <blockquote cite="/podcast/elixir-wizards/s4e14-windholtz/">
         The really important thing that architecture should do is carve out a safe space so you can build your essential complexity. And that safe space is where I want to work in.</blockquote> <cite>— Mark Windholtz in <a href="/podcast/elixir-wizards/s4e14-windholtz/">S4E14 on Domain-Driven Design</a></cite>
       {% include old-season-episodes.html season='Season 4' %}

--- a/podcast/elixir-wizards/season-nine.html
+++ b/podcast/elixir-wizards/season-nine.html
@@ -35,8 +35,12 @@ include_rss: true
   <!-- main body content -->
   <div class="content-page-wrapper">
     <section class="section content-block podcast" id="s9">
-      <iframe src="https://player.fireside.fm/v2/IAs5ixts+kKtocYfA?theme=dark" width="960" height="200" frameborder="0" scrolling="no" ></iframe>
-      <iframe width="960" height="540" src="https://www.youtube.com/embed/videoseries?si=kJoC92Hy7o-G6StS&amp;list=PLTDLmInI9YaClcsqFbIk28NvTGwoElOQw" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+      <div class="podcast-audio-container">
+        <iframe src="https://player.fireside.fm/v2/IAs5ixts+kKtocYfA?theme=dark" width="960" height="200" frameborder="0" scrolling="no" ></iframe>
+      </div>
+      <div class="podcast-video-container">
+        <iframe width="960" height="540" src="https://www.youtube.com/embed/videoseries?si=kJoC92Hy7o-G6StS&amp;list=PLTDLmInI9YaClcsqFbIk28NvTGwoElOQw" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+      </div>
 
       <blockquote cite="/podcast/elixir-wizards/s9-e11-chris-miller-programming-language/">
         Inherently, language is about communicating ideas and communicating ideas is

--- a/podcast/elixir-wizards/season-one.html
+++ b/podcast/elixir-wizards/season-one.html
@@ -28,8 +28,12 @@ include_rss: true
   <!-- main body content -->
   <div class="content-page-wrapper">
     <section class="section content-block podcast" id="s1">
-      <iframe src="https://player.fireside.fm/v2/IAs5ixts+zDmDU2aS?theme=dark" width="960" height="200" frameborder="0" scrolling="no"></iframe>
-      <iframe width="960" height="540" src="https://www.youtube.com/embed/videoseries?si=t_xrad4vOepPuh-z&amp;list=PLTDLmInI9YaADEbPZegOitsoWANHFOYjB" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+      <div class="podcast-audio-container">
+        <iframe src="https://player.fireside.fm/v2/IAs5ixts+zDmDU2aS?theme=dark" width="960" height="200" frameborder="0" scrolling="no"></iframe>
+      </div>
+      <div class="podcast-video-container">
+        <iframe width="960" height="540" src="https://www.youtube.com/embed/videoseries?si=t_xrad4vOepPuh-z&amp;list=PLTDLmInI9YaADEbPZegOitsoWANHFOYjB" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+      </div>
       {% include old-season-episodes.html season='Season 1' %}
     </section>
 

--- a/podcast/elixir-wizards/season-seven.html
+++ b/podcast/elixir-wizards/season-seven.html
@@ -29,8 +29,12 @@ include_rss: true
   <!-- main body content -->
   <div class="content-page-wrapper">
     <section class="section content-block podcast" id="s7">
-      <iframe src="https://player.fireside.fm/v2/IAs5ixts+sH54rwhi?theme=dark" width="960" height="200" frameborder="0" scrolling="no"></iframe>
-      <iframe width="960" height="540" src="https://www.youtube.com/embed/videoseries?si=ZPjkRAV7K_EqWt3w&amp;list=PLTDLmInI9YaBR0qFF2MnnzxN3NHN2wNrJ" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+      <div class="podcast-audio-container">
+        <iframe src="https://player.fireside.fm/v2/IAs5ixts+sH54rwhi?theme=dark" width="960" height="200" frameborder="0" scrolling="no"></iframe>
+      </div>
+      <div class="podcast-video-container">
+        <iframe width="960" height="540" src="https://www.youtube.com/embed/videoseries?si=ZPjkRAV7K_EqWt3w&amp;list=PLTDLmInI9YaBR0qFF2MnnzxN3NHN2wNrJ" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+      </div>
       <blockquote cite="/podcast/elixir-wizards/s7e2-jose/">
         The part that was fascinating to me when I got into Cars.com was to realize what the business actually is: it’s a huge ETL pipeline of different data points.</blockquote> <cite>— Angel Jose in <a href="/podcast/elixir-wizards/s7e2-jose/"> S7E2 on Re-Platforming One of the Original Dot Coms</a></cite>
 

--- a/podcast/elixir-wizards/season-six.html
+++ b/podcast/elixir-wizards/season-six.html
@@ -29,8 +29,12 @@ include_rss: true
   <!-- main body content -->
   <div class="content-page-wrapper">
     <section class="section content-block podcast" id="s6">
-      <iframe src="https://player.fireside.fm/v2/IAs5ixts+W5dAvToG?theme=dark" width="960" height="200" frameborder="0" scrolling="no"></iframe>
-      <iframe width="960" height="540" src="https://www.youtube.com/embed/videoseries?si=IU4DagKKQUoP39VM&amp;list=PLTDLmInI9YaCb9O1AEbAUkqD-cropZNNs" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+      <div class="podcast-audio-container">
+        <iframe src="https://player.fireside.fm/v2/IAs5ixts+W5dAvToG?theme=dark" width="960" height="200" frameborder="0" scrolling="no"></iframe>
+      </div>
+      <div class="podcast-video-container">
+        <iframe width="960" height="540" src="https://www.youtube.com/embed/videoseries?si=IU4DagKKQUoP39VM&amp;list=PLTDLmInI9YaCb9O1AEbAUkqD-cropZNNs" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+      </div>
       <blockquote cite="/podcast/elixir-wizards/s6e1-virding/">
         We wanted to build fault tolerant systems, and things are going to go wrong. They always do. You need to just accept the fact things are going to go wrong. How can you build systems that can handle errors?</blockquote> <cite>— Robert Virding in <a href="/podcast/elixir-wizards/s6e1-virding/">S6E1 on The Roots of Erlang</a></cite>
       {% include old-season-episodes.html season='Season 6' %}

--- a/podcast/elixir-wizards/season-ten.html
+++ b/podcast/elixir-wizards/season-ten.html
@@ -42,7 +42,9 @@ include_rss: true
   <!-- main body content -->
   <div class="content-page-wrapper">
     <section class="section content-block podcast" id="s10">
-      <iframe width="960" height="540" src="https://www.youtube.com/embed/videoseries?si=i95alPX8uY01YXrw&amp;list=PLTDLmInI9YaC3ahMuDiPMDG3_kcwAksYz" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+      <div class="podcast-video-container">
+        <iframe width="960" height="540" src="https://www.youtube.com/embed/videoseries?si=i95alPX8uY01YXrw&amp;list=PLTDLmInI9YaC3ahMuDiPMDG3_kcwAksYz" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+      </div>
       {% include old-season-episodes.html season='Season 10' %}
     </section>
 

--- a/podcast/elixir-wizards/season-three.html
+++ b/podcast/elixir-wizards/season-three.html
@@ -28,8 +28,12 @@ include_rss: true
   <!-- main body content -->
   <div class="content-page-wrapper">
     <section class="section content-block podcast" id="s3">
-      <iframe src="https://player.fireside.fm/v2/IAs5ixts+5_ewBeuK?theme=dark" width="960" height="200" frameborder="0" scrolling="no"></iframe>
-      <iframe width="960" height="540" src="https://www.youtube.com/embed/videoseries?si=MZJrmOs6YRdWtR3K&amp;list=PLTDLmInI9YaDbhMRpGuYpboVNbp1Fl9PD" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+      <div class="podcast-audio-container">
+        <iframe src="https://player.fireside.fm/v2/IAs5ixts+5_ewBeuK?theme=dark" width="960" height="200" frameborder="0" scrolling="no"></iframe>
+      </div>
+      <div class="podcast-video-container">
+        <iframe width="960" height="540" src="https://www.youtube.com/embed/videoseries?si=MZJrmOs6YRdWtR3K&amp;list=PLTDLmInI9YaDbhMRpGuYpboVNbp1Fl9PD" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+      </div>
       <blockquote cite="/podcast/elixir-wizards/s3e10-debenedetto-dakin/">
         Challenging them, pushing them and still giving them enough information to figure something out and to get that win and to fix that bug or solve that problem or get to that next level of understanding – I think that’s how you can really teach someone to fall in love with coding.</blockquote> <cite>— Sophie DeBenedetto in <a href="/podcast/elixir-wizards/s3e10-debenedetto-dakin/">S3E10 on Training and Building Elixir Projects Under Constraints</a></cite>
       {% include old-season-episodes.html season='Season 3' %}

--- a/podcast/elixir-wizards/season-twelve.html
+++ b/podcast/elixir-wizards/season-twelve.html
@@ -35,11 +35,15 @@ include_rss: true
   <div class="content-page-wrapper">
     <section class="section content-block podcast" id="s12">
       <h3>Watch The Season on YouTube!</h3>
-      <iframe width="960" height="540" src="https://www.youtube.com/embed/videoseries?si=36mpZQNr2Qh1DWqI&amp;list=PLTDLmInI9YaDmSMm9BqdsZUsexB4CwWsZ" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+      <div class="podcast-video-container">
+        <iframe width="960" height="540" src="https://www.youtube.com/embed/videoseries?si=36mpZQNr2Qh1DWqI&amp;list=PLTDLmInI9YaDmSMm9BqdsZUsexB4CwWsZ" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+      </div>
       {% include season-episodes.html season='Season 12' %}
       <br/><br/>
       <h3>Audio Only YouTube Playlist</h3>
-      <iframe width="960" height="540" src="https://www.youtube.com/embed/videoseries?si=svLsfPx6roJ0VZL7&amp;list=PLTDLmInI9YaDEZXUcw-NXbLza8bH8BnM0" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+      <div class="podcast-video-container">
+        <iframe width="960" height="540" src="https://www.youtube.com/embed/videoseries?si=svLsfPx6roJ0VZL7&amp;list=PLTDLmInI9YaDEZXUcw-NXbLza8bH8BnM0" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+      </div>
     </section>
 
     <section>

--- a/podcast/elixir-wizards/season-two.html
+++ b/podcast/elixir-wizards/season-two.html
@@ -28,8 +28,12 @@ include_rss: true
   <!-- main body content -->
   <div class="content-page-wrapper">
     <section class="section content-block podcast" id="s2">
-      <iframe src="https://player.fireside.fm/v2/IAs5ixts+BeykEzKP?theme=dark" width=960 height="200" frameborder="0" scrolling="no"></iframe>
-      <iframe width="960" height="540" src="https://www.youtube.com/embed/videoseries?si=OMUnjgKzmpYtO1Rc&amp;list=PLTDLmInI9YaCclg83fLcWa-mgZ2H88aAO" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+      <div class="podcast-audio-container">
+        <iframe src="https://player.fireside.fm/v2/IAs5ixts+BeykEzKP?theme=dark" width=960 height="200" frameborder="0" scrolling="no"></iframe>
+      </div>
+      <div class="podcast-video-container">
+        <iframe width="960" height="540" src="https://www.youtube.com/embed/videoseries?si=OMUnjgKzmpYtO1Rc&amp;list=PLTDLmInI9YaCclg83fLcWa-mgZ2H88aAO" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+      </div>
       <blockquote cite="/podcast/elixir-wizards/season-two-zelenka/">
         Contributing back to libraries both forces you to read how other people are writing code and collaborate with other people.</blockquote> <cite>— Brooklyn Zelenka in <a href="/podcast/elixir-wizards/season-two-zelenka/">S2E1 Elixir Internals on Witchcraft</a></cite>
       {% include old-season-episodes.html season='Season 2' %}


### PR DESCRIPTION
This adds a wrapper around all the YouTube and Fireside `iframe` elements for the podcast so that they're responsive to window width. The Fireside embed, unlike YouTube's, has an inconsistent aspect ratio with some built-in breakpoints that change the content within the `iframe`. This meant that at some widths it would overlap with the content after it. To address this, I added an unconventional `@media` breakpoint.

See https://github.com/smartlogic/smartlogic.io/issues/313 for more info