### PR TITLE
Fix responsiveness of pillar cards on landing page

### DIFF
--- a/_sass/components/pillars.scss
+++ b/_sass/components/pillars.scss
@@ -17,6 +17,10 @@
 			font-size: 28px;
 		}
 		
+		@include tablet{
+			font-size: 26px;
+		}
+
 		@include phone{
 			font-size: 22px;
 		}
@@ -29,10 +33,14 @@
 			@media (max-width: 1024px) {
 			  font-size: 28px;
 			}
+
+			@include tablet{
+				font-size: 26px;
+			}
 			
 			@include phone{
 			  font-size: 22px;
-			}			
+			}
 		}	
 	}
 
@@ -53,11 +61,20 @@
 	gap: 24px;
 	padding: 24px;
 	height: 250px;
+	flex: 1;
 	>p {
 		font-size: 28px;
 		font-weight: 450;
 		color: $black;
 		text-align: center;
+
+		@media (max-width: 1024px) {
+			font-size: 24px;
+		  }
+
+		@include tablet{
+			font-size: 22px;
+		}
 
 		@include phone{
 			font-size: 18px;


### PR DESCRIPTION
Fixed responsiveness of pillar cards on landing page.

Below is a screenshot of a 375 x 667 px display showing the card with the longest text content.

<img width="375" alt="Screenshot 2024-09-03 at 9 50 21 AM" src="https://github.com/user-attachments/assets/451217b1-ebcd-48f4-8711-60a8582fab61">
