### PR TITLE
Tweak Text and Make Modals & Form Responsive on Mobile

### DIFF
--- a/_includes/at_a_glance.html
+++ b/_includes/at_a_glance.html
@@ -1,5 +1,5 @@
 <section class="section at-a-glance landing-page">
-  <h2 class="at-a-glance__title">SmartLogic At-A-Glance</h2>
+  <h2 class="at-a-glance__title">SmartLogic At A Glance</h2>
   <div class="at-a-glance__stats">
     <div class="stat">
       <h3 class="stat__title">YEARS IN BUSINESS</h3>
@@ -10,7 +10,7 @@
       <p class="stat__value">200+</p>
     </div>
     <div class="stat">
-      <h3 class="stat__title">RESOURCE BENCH</h3>
+      <h3 class="stat__title">TEAM MEMBERS</h3>
       <p class="stat__value">25+</p>
     </div>
     <div class="stat">
@@ -20,21 +20,21 @@
   </div>
   <h2 class="at-a-glance__subtitle">Engagements Include</h2>
   <div class="at-a-glance__engagements">
-    <div class="engagement full-lifecycle" data-title="Full Lifecycle" data-description="From Product Discovery through all stages of User Experience, Implementation, Maintenance and Continued Innovation.">
+    <div class="engagement full-lifecycle" data-title="Full Lifecycle" data-description="From Product Discovery through all stages of User Experience, Implementation, Support, Maintenance, and Continued Innovation.">
       <p class="engagement__title">Full Lifecycle</p>
-      <div class="engagement__description">From Product Discovery through all stages of User Experience, Implementation, Maintenance and Continued Innovation.</div>
+      <div class="engagement__description">From Product Discovery through all stages of User Experience, Implementation, Support, Maintenance, and Continued Innovation.</div>
     </div>
     <div class="engagement team-augmentation" data-title="Team Augmentation" data-description="Accelerate your projects with a dedicated Scrum Team, offering Project Management, Software Engineering, Design, Development, and QA Services.">
       <p class="engagement__title">Team Augmentation</p>
       <div class="engagement__description">Accelerate your projects with a dedicated Scrum Team, offering Project Management, Software Engineering, Design, Development, and QA Services.</div>
     </div>
-    <div class="engagement replatforming" data-title="Replatforming" data-description="Custom solutions for migrating legacy systems to enhance performance, scalability, and security, keeping your business competitive.">
+    <div class="engagement replatforming" data-title="Replatforming" data-description="Migrate Legacy Systems to modern tech stacks to enhance Performance, Scalability, Security, and keep your business competitive.">
       <p class="engagement__title">Replatforming</p>
-      <div class="engagement__description">Custom solutions for migrating legacy systems to enhance performance, scalability, and security, keeping your business competitive.</div>
+      <div class="engagement__description">Migrate Legacy Systems to modern tech stacks to enhance Performance, Scalability, Security, and keep your business competitive.</div>
     </div>
-    <div class="engagement rd-mvp" data-title="R&D and MVP" data-description="Support early-stage projects with MVP Scoping, Design, and Strategy to help raise funds, prove concepts, or plan roadmaps.">
+    <div class="engagement rd-mvp" data-title="R&D and MVP" data-description="Support early-stage projects with MVP development to help secure funds, develop Proof of Concepts, or plan Roadmaps.">
       <p class="engagement__title">R&D and MVP</p>
-      <div class="engagement__description">Support early-stage projects with MVP Scoping, Design, and Strategy to help raise funds, prove concepts, or plan roadmaps.</div>
+      <div class="engagement__description">Support early-stage projects with MVP development to help secure funds, develop Proof of Concepts, or plan Roadmaps.</div>
     </div>
   </div>
   <div class="at-a-glance__cta">

--- a/_includes/features.html
+++ b/_includes/features.html
@@ -1,5 +1,5 @@
 <section class="section features-container overview-section landing-page">
-  <h2 class="section-title">We are Specialists in</h2>
+  <h2 class="section-title">We are specialists in</h2>
     <div class="overview-logo-bar">
       <img class="features-logo" src="{{ '/images/logo/logos-tech/elixir.png' | relative_url }}" alt="Elixir icon"/>
       <img class="features-logo" src="{{ '/images/logo/logos-tech/rails.png' | relative_url }}" alt="Ruby on Rails icon"/>

--- a/_includes/testimonials-and-awards.html
+++ b/_includes/testimonials-and-awards.html
@@ -6,7 +6,7 @@
   </blockquote>
     <p>—<cite>Kristi Katz, Head of World Central Kitchen Direct</cite></p>
 
-  <div class="overview-logo-bar">
+  <div class="overview-logo-bar testimonial-logo-bar">
     <img class="testimonials-logo" src="/images/contents/ClutchBadge.png" alt="Clutch Top Company 2021 Badge"/>
     <img class="testimonials-logo" src="/images/contents/inno-fire.png" alt="Inno Fire Awards Logo"/>
   </div>

--- a/_sass/components/at_a_glance.scss
+++ b/_sass/components/at_a_glance.scss
@@ -14,6 +14,10 @@
     color: $dark-black;
     margin-bottom: 4rem;
     padding-top: 2rem;
+
+    @include phone{
+      margin-bottom: 0rem;
+    }
   }
 
   &__subtitle {
@@ -22,6 +26,10 @@
     color: $dark-black;
     margin-bottom: 1rem;
     padding-top: 60px;
+
+    @include phone{
+      padding-top: 40px;
+    }
   }
 
   &__stats {
@@ -144,7 +152,11 @@
         @media (min-width: 1025px) and (max-width: 1290px) {
             top: 20%;
           }
-      } 
+
+        @include phone{
+          padding-bottom: 20px;
+        }
+      }
 
       .engagement__description {
         @include circular(regular);
@@ -196,7 +208,7 @@
   }
 }
 
-// At a glance modal for jotform form
+// Get started modal for jotform form located under the "at a glance" section
 .modal {
   display: none;
   position: fixed;
@@ -208,6 +220,10 @@
   overflow-y: auto;
   background: rgba(99, 187, 176, 0.9);
   background: linear-gradient(135deg, rgba(99, 187, 176, 0.9), rgba(249, 223, 82, 0.9));
+
+  @media (max-width: 600px) {
+    overflow: hidden;
+  }
 }
 
 .modal-content {
@@ -219,6 +235,21 @@
   height: 80%;
   max-width: 800px;
   max-height: 800px;
+
+  @media (max-width: 1060px){
+    top: 50%;
+    left: 47%;
+  }
+
+  @media (max-width: 600px) {
+    top: 0;
+    left: 0;
+    transform: none;
+    width: 100%;
+    height: 100%;
+    max-width: 100%;
+    max-height: 100%;
+  }
 }
 
 .close {
@@ -237,5 +268,27 @@
     width: 100%;
     height: 100%;
     cursor: pointer;
+  }
+
+  @media (max-width: 600px) {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+  }
+}
+
+@media (max-width: 600px) {
+  .modal-content iframe {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100% !important;
+    height: 100% !important;
+    max-width: 100% !important;
+    max-height: 100% !important;
+    border: none !important;
+    padding: 0 !important;
+    margin: 0 !important;
+    z-index: 1002;
   }
 }

--- a/_sass/components/case_studies.scss
+++ b/_sass/components/case_studies.scss
@@ -4,6 +4,9 @@
   @include tablet{
     padding: 10px;
   }
+  @include phone{
+    padding-bottom: 40px;
+  }
 
   .container {
     max-width: 1800px;

--- a/_sass/components/modal.scss
+++ b/_sass/components/modal.scss
@@ -36,10 +36,16 @@
     gap: 32px;
     z-index: 1002;
 
-	@media (max-width: 900px){
+	@media (max-width: 1000px){
 		flex-direction: column;
-		padding-top: 20px;
+		padding: 20px;
 	}
+	@include phone{
+        margin-left: 0;
+        max-width: 100%;
+        padding: 0px;
+        height: 100%;
+    }
 }
 .modal-case-study-details {
 	max-width: 48%;	
@@ -49,27 +55,58 @@
 	z-index: 1003;
 	padding-bottom: 100px;
 
-	@include tablet{
+	@include laptop{
 		max-width: 98%;
+		padding-bottom: 40px
+	}
+	@include phone{
+		gap: 24px;
+		padding-bottom: 0px;
 	}
 	h2 {
 		font-size: 32px;
 		font-weight: 700;
 		color: $black;
+
+		@include phone{
+		  font-size: 28px;
+		  padding-left: 58px;
+		}
 	}
 	p {
 		color: $black;
 		font-size: 18px;
+
+		@include tablet{
+			font-size: 16px;
+		  }
+		@include phone{
+			font-size: 14px;
+			padding-right: 20px;
+			padding-left: 60px;
+		  }
 	}
 	p.overview {
 		font-size: 28px;
 		font-weight: 450;
+
+		@include tablet{
+			font-size: 24px;
+		  }
+
+		@include phone{
+			font-size: 20px;
+		  }
 	}
 	h5 {
 		color: $black;
 		font-size: 16px;
 		font-weight: 700;
 		text-transform: uppercase;
+
+		@include phone{
+			padding-left: 60px;
+		}
 	}
 	ul {
 		padding-left: 20px;
@@ -77,18 +114,38 @@
 		color: $black;
 		font-size: 18px;
 		font-weight: 450;
+
+		@include phone{
+			font-size: 14px;
+			padding-left: 74px;
+		}
 	}
 	img {
         max-width: 100%;
         height: auto;
         align-self: left;
-		padding-bottom: 0px !important;
+		padding-bottom: 0px;
+
+		@include tablet{
+			max-width: 80%;
+			padding-bottom: 50px;
+		}
+		@include phone{
+			max-width: 60%;
+			padding-bottom: 70px;
+		}
     }
 	.modal-logo {
         max-width: 60%;
         height: auto;
 		margin-left: -15px;
 		padding-bottom: 0px !important;
+
+		@include phone{
+			max-width: 60%;
+			padding-left: 70px;
+			padding-top: 30px;
+		}
     }
 }
 .modal-case-study-details:last-child {
@@ -115,6 +172,13 @@
     &:hover {
         background-color: $teal;
     }
+
+	@include phone{
+		width: 160px;
+		height: 48px;
+		margin-left: 60px;
+		margin-top: 10px;
+	}
 }
 
 .full-button {
@@ -129,6 +193,10 @@
     text-align: center;
     text-decoration: none;
     cursor: pointer;
+
+	@include phone{
+		font-size: 14px;
+	}
 }
 .button-container:hover{
     background-color: $teal;
@@ -141,6 +209,22 @@
 .modal-overlaping-picture-first{
     width: 85%;
 	padding-top: 100px;
+
+	@include tablet{
+		width: 70%;
+		padding-top: 0px;
+		padding-left: 20px;
+	}
+	@include phone{
+		width: 60%;
+		padding-top: 0px;
+		padding-left: 40px;
+	}
+	@include minphone{
+		width: 60%;
+		padding-top: 0px;
+		padding-left: 60px;
+	}
 }
 .modal-overlaping-picture-second{
     width: 100%;
@@ -148,6 +232,21 @@
     top: 325px;
     left: 75px;
 	z-index: 1004;
+
+	@include tablet{
+		width: 70%;
+		padding-top: 0px;
+		padding-right: 100px;
+		top: 130px;
+		left: 140px;
+	}
+	@include phone{
+		width: 70%;
+		padding-top: 0px;
+		padding-right: 100px;
+		top: 130px;
+		left: 140px;
+	}
 }
 .modal-close {
 	position: absolute;
@@ -158,4 +257,14 @@
 	font-weight: bold;
 	cursor: pointer;
 	z-index: 1005;
+
+	@include tablet{
+		top: 20px;
+		right: 30px;
+	}
+
+	@include phone{
+		top: 10px;
+		right: 18px;
+	}
 }

--- a/_sass/components/pillars.scss
+++ b/_sass/components/pillars.scss
@@ -50,6 +50,7 @@
 	
 	@include phone{
 	  padding: 10px;
+	  gap: 10px;
 	}
 }
 .pillar-text-content {

--- a/_sass/components/statement.scss
+++ b/_sass/components/statement.scss
@@ -9,6 +9,7 @@
   
 	@include phone{
 	  width: 90%;
+	  padding: 40px;
 	}
 }
 .statement-container{

--- a/_sass/components/testimonials.scss
+++ b/_sass/components/testimonials.scss
@@ -20,7 +20,7 @@
     @include phone{
       padding: 20px;
       width: 90%;
-    }
+    }		
 	}
 	p {
 		font-size: 28px;

--- a/_sass/components/testimonials.scss
+++ b/_sass/components/testimonials.scss
@@ -18,9 +18,9 @@
     }
     
     @include phone{
-      padding: 10px;
+      padding: 20px;
       width: 90%;
-    }		
+    }
 	}
 	p {
 		font-size: 28px;
@@ -38,6 +38,10 @@
 	span {
 		font-size: 14px;
 		font-weight: 450;
+	}
+
+	@include phone{
+	  padding: 30px;
 	}
 }
 .testimonials-logo {

--- a/_sass/layout/setups.scss
+++ b/_sass/layout/setups.scss
@@ -155,6 +155,10 @@ a {
   }
 .overview-section {
     padding: 30px 0;
+
+    @media (max-width: 1024){
+        padding: 0px;
+    }
 }
 .quote-inside {
     display: flex;

--- a/_sass/pages/main.scss
+++ b/_sass/pages/main.scss
@@ -15,6 +15,16 @@
   align-items: center;
   justify-content: center;
   align-content: space-around;
+
+  @include phone{
+    padding-bottom: 0px;
+  }
+}
+.testimonial-logo-bar{
+  @include phone{
+    padding-bottom: 20px;
+    flex-wrap: nowrap;
+  }
 }
 .logobar{
   padding: 25px 15px;


### PR DESCRIPTION
### Changes made:

#### Text changes
- Remove at-a-glance (hyphens)
- Change to 25+ "Team Members"
- Lowercase the S in “We are Specialists in”
- Under Full Life Cycle - add the word “Support” and a comma before Maintenance
- For Replatforming - change the text to “Migrate Legacy Systems to modern tech stacks to enhance Performance, Scalability, Security, and keep your business competitive.” (with the capitalization as is)
- For R&D and MVP - change text to “Support early-stage projects with MVP development to help secure funds, develop Proof of Concepts, or plan Roadmaps.

#### Mobile Responsiveness
- Make "Get Started" modal (jotform) more responsive on mobile
- Make case study modals responsive on phone and mini phone

#### Lots of testing on mobile
